### PR TITLE
fix:update MessageTaskDetailModal.razor MessageTaskHistoryStatus style

### DIFF
--- a/src/Web/Masa.Mc.Web.Admin/Pages/MessageTasks/Modules/MessageTaskDetailModal.razor
+++ b/src/Web/Masa.Mc.Web.Admin/Pages/MessageTasks/Modules/MessageTaskDetailModal.razor
@@ -7,17 +7,17 @@
                     <HeaderContent>
                         <div class="subtitle2 emphasis2--text">@T("DisplayName.MessageTaskHistory")</div>
                         <Masa.Mc.Web.Admin.Components.Pickers.DateRangePicker Class="btn-fill-line mt-6" IconClass="mr-9" @bind-StartTime="_queryParam.StartTime" @bind-EndTime="_queryParam.EndTime" OnChange="LoadData" />
-                        <div class="status-select mb-9">
+                        <div class="status-select">
                             <MSelect @bind-Value="@_queryParam.Status"
                                      Items="@(GetEnumList<MessageTaskHistoryStatuses>())"
                                      Label="@T("DisplayName.MessageTaskHistoryStatus")"
                                      ItemText="@(item => T($"DisplayName.MessageTaskHistoryStatus.{item.ToString()}"))"
                                      ItemValue="item => item"
                                      Dense
-                                     Solo
                                      Outlined
                                      Clearable
                                      HideDetails="@("auto")"
+                                     MenuProps="@(props => { props.OffsetY = true; })"
                                      Class="mt-6 justify-center"
                                      TItem="MessageTaskHistoryStatuses"
                                      TItemValue="MessageTaskHistoryStatuses"


### PR DESCRIPTION
# Description

1. After the status is selected, the label does not move to the upper left corner of the drop-down box
2. When selecting the status, the value will block the input box label

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
