### PR TITLE
Fix: Message record, advanced search, Select component text is trunca…

### DIFF
--- a/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Subjects/Validator/CreateExternalUserDtoValidator.cs
+++ b/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Subjects/Validator/CreateExternalUserDtoValidator.cs
@@ -7,9 +7,9 @@ public class CreateExternalUserDtoValidator : AbstractValidator<CreateExternalUs
 {
     public CreateExternalUserDtoValidator()
     {
-        RuleFor(inputDto => inputDto.DisplayName).Required("DisplayNameRequired").Length(2, 50).ChineseLetterNumber();
-        RuleFor(inputDto => inputDto.PhoneNumber).Required("PhoneNumberRequired").Phone().When(u => string.IsNullOrEmpty(u.Email) || !string.IsNullOrEmpty(u.PhoneNumber));
-        RuleFor(inputDto => inputDto.Email).Required("EmailRequired")
+        RuleFor(inputDto => inputDto.DisplayName).Required().Length(2, 50).ChineseLetterNumber();
+        RuleFor(inputDto => inputDto.PhoneNumber).Required().Phone().When(u => string.IsNullOrEmpty(u.Email) || !string.IsNullOrEmpty(u.PhoneNumber));
+        RuleFor(inputDto => inputDto.Email).Required()
             .Email().WithMessage("EmailInvalid")
             .When(u => string.IsNullOrEmpty(u.PhoneNumber) || !string.IsNullOrEmpty(u.Email));
     }

--- a/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Subjects/Validator/CreateExternalUserDtoValidator.cs
+++ b/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Subjects/Validator/CreateExternalUserDtoValidator.cs
@@ -7,7 +7,7 @@ public class CreateExternalUserDtoValidator : AbstractValidator<CreateExternalUs
 {
     public CreateExternalUserDtoValidator()
     {
-        RuleFor(inputDto => inputDto.DisplayName).Required().Length(2, 50).ChineseLetterNumber();
+        RuleFor(inputDto => inputDto.DisplayName).Required("UserDisplayNameRequired").Length(2, 50).WithMessage("UserDisplayNameLength").ChineseLetterNumber().WithMessage("UserDisplayNameChineseLetterNumber");
         RuleFor(inputDto => inputDto.PhoneNumber).Required().Phone().When(u => string.IsNullOrEmpty(u.Email) || !string.IsNullOrEmpty(u.PhoneNumber));
         RuleFor(inputDto => inputDto.Email).Required()
             .Email().WithMessage("EmailInvalid")

--- a/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor
+++ b/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor
@@ -12,7 +12,7 @@
             OnSave="HandleOk"
             OnCancel="HandleCancel">
         <ChildContent>
-            <MForm Model="_model" EnableValidation EnableI18n Class="full-height">
+            <MForm Model="_model" EnableValidation EnableI18n Class="full-height" @ref="_form">
                 <STextField Label="@T("User.DisplayName")" @bind-Value="_model.DisplayName"></STextField>
                 <STextField Class="mt-6" Label="@T("PhoneNumber")" @bind-Value="_model.PhoneNumber"></STextField>
                 <STextField Class="mt-6" Label="@T("Email")" @bind-Value="_model.Email"></STextField>

--- a/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor.cs
+++ b/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor.cs
@@ -14,6 +14,8 @@ public partial class ExternalUserCreateModal : AdminCompontentBase
     private CreateExternalUserDto _model = new();
     private bool _visible;
 
+    private MForm _form;
+
     public async Task OpenModalAsync()
     {
         ResetForm();
@@ -22,6 +24,8 @@ public partial class ExternalUserCreateModal : AdminCompontentBase
             _visible = true;
             StateHasChanged();
         });
+
+        _form?.ResetValidation();
     }
 
     private void HandleCancel()

--- a/src/Web/Masa.Mc.Web.Admin/Pages/MessageRecords/MessageRecordManagement.razor
+++ b/src/Web/Masa.Mc.Web.Admin/Pages/MessageRecords/MessageRecordManagement.razor
@@ -8,7 +8,7 @@
             @if (advanced)
             {
                 <div class="fold d-inline-flex">
-                    <MRow NoGutters>
+                    <MRow NoGutters Class="pt-1">
                         <MCol Md="2">
                             <SSelect Small @bind-Value="@_queryParam.TimeType"
                                  Items="@(GetEnumList<MessageRecordTimeTypes>())"
@@ -54,7 +54,7 @@
                     </MRow>
                 </div>
             }
-            <div class="d-flex search-panel-right @(!isAnimate?"full-width":"") @(isAnimate?"animate__animated":"") @(!advanced?"animate__searchOpen":"animate__searchShrink")">
+            <div class="d-flex search-panel-right pt-1 @(!isAnimate?"full-width":"") @(isAnimate?"animate__animated":"") @(!advanced?"animate__searchOpen":"animate__searchShrink")">
                 <DefaultSearch @bind-Value="_queryParam.Filter" Clearable Class="rounded-2 search" Placeholder="@T("Search")" Dense OnEnter="RefreshAsync" OnClearClick="HandleClearAsync" />
                 <div @onclick="ToggleAdvanced" class="ml-6 d-flex button fill">
                     <MIcon Class="ma-auto" Color="emphasis2" Size=20>

--- a/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/en-US.json
+++ b/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/en-US.json
@@ -248,5 +248,8 @@
   "TaskWithdrawnConfirmationMessage": "Are you sure withdrawn task {0}?",
   "DisplayName.AppChannelProviders": "Provider",
   "DisplayName.AppChannelProviders.GeTui": "GeTui",
-  "DisplayName.AppChannelProviders.JPush": "JPush"
+  "DisplayName.AppChannelProviders.JPush": "JPush",
+  "UserDisplayNameRequired": "Please fill in the displayName",
+  "UserDisplayNameLength": "The length of displayName can only be between 2 and 50",
+  "UserDisplayNameChineseLetterNumber": "DisplayName can only be Chinese/letter/number"
 }

--- a/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/zh-CN.json
+++ b/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/zh-CN.json
@@ -370,5 +370,7 @@
   "TaskWithdrawnConfirmationMessage": "确定撤销任务{0}吗？",
   "DisplayName.AppChannelProviders": "提供商",
   "DisplayName.AppChannelProviders.GeTui": "个推",
-  "DisplayName.AppChannelProviders.JPush": "极光"
+  "DisplayName.AppChannelProviders.JPush": "极光",
+  "DisplayName": "用户昵称",
+  "Provider": "提供商"
 }

--- a/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/zh-CN.json
+++ b/src/Web/Masa.Mc.Web.Admin/wwwroot/i18n/zh-CN.json
@@ -371,6 +371,8 @@
   "DisplayName.AppChannelProviders": "提供商",
   "DisplayName.AppChannelProviders.GeTui": "个推",
   "DisplayName.AppChannelProviders.JPush": "极光",
-  "DisplayName": "用户昵称",
+  "UserDisplayNameRequired": "用户昵称是必需的",
+  "UserDisplayNameLength": "用户昵称的长度必须在 2 到 50 字符。",
+  "UserDisplayNameChineseLetterNumber": "用户昵称必须是中文、数字、字母。",
   "Provider": "提供商"
 }


### PR DESCRIPTION
…ted. After successfully adding an external member, when you add it again, opening a popover immediately triggers form validation. Look up prompt i18n (Modal dialog)

# Description

_Fix: 
  1.Message record, advanced search, Select component text is truncated. 
  2.After successfully adding an external member, when you add it again, opening a popover immediately triggers form validation.
  3.Look up prompt i18n (Modal dialog)_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
