### PR TITLE
Fix: After successfully adding an external member, when you add it ag…

### DIFF
--- a/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Channels/Validator/ChannelUpsertDtoValidator.cs
+++ b/src/Contracts/Masa.Mc.Contracts.Admin/Dtos/Channels/Validator/ChannelUpsertDtoValidator.cs
@@ -11,7 +11,7 @@ public class ChannelUpsertDtoValidator : AbstractValidator<ChannelUpsertDto>
             .ChineseLetterNumberSymbol().WithMessage("ChannelDisplayNameChineseLetterNumberSymbol")
             .Length(2, 50).WithMessage("ChannelDisplayNameRequiredLength");
         RuleFor(inputDto => inputDto.Code)
-            .Required("ChannelDisplayNameRequired")
+            .Required("ChannelCodeRequired")
             .LetterNumberSymbol().WithMessage("ChannelDisplayNameChineseLetterNumberSymbol")
             .Length(2, 50).WithMessage("ChannelDisplayNameRequiredLength");
         RuleFor(inputDto => inputDto.Type).IsInEnum();

--- a/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor.cs
+++ b/src/Web/Masa.Mc.Web.Admin/Components/Modules/Subjects/ExternalUserCreateModal.razor.cs
@@ -24,13 +24,12 @@ public partial class ExternalUserCreateModal : AdminCompontentBase
             _visible = true;
             StateHasChanged();
         });
-
-        _form?.ResetValidation();
     }
 
     private void HandleCancel()
     {
         _visible = false;
+        _form?.Reset();
     }
 
     private async Task HandleOk()
@@ -38,6 +37,7 @@ public partial class ExternalUserCreateModal : AdminCompontentBase
         var user = await CreateExternalUserAsync(_model);
 
         _visible = false;
+        _form?.Reset();
 
         if (OnOk.HasDelegate)
         {


### PR DESCRIPTION
…ain, opening a popover immediately triggers form validation. Look up prompt i18n: Channel Id tips error

# Description

_Fix: 
 1.After successfully adding an external member, when you add it again, opening a popover immediately triggers form validation. 
 2.Look up prompt i18n: Channel Id tips error_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
