### PR TITLE
refactor: Support OPPO push service and optimize multi platform push logic

### DIFF
--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiConstants.cs
@@ -5,5 +5,5 @@ namespace Masa.Mc.Infrastructure.AppNotification.Getui;
 
 public static class GetuiConstants
 {
-    public const string DomainUrl = "https://api.push.oppomobile.com/server/v1/auth";
+    public const string DomainUrl = "http://api.getui.com/apiex.htm";
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiConstants.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Getui;
+
+public static class GetuiConstants
+{
+    public const string DomainUrl = "https://api.push.oppomobile.com/server/v1/auth";
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiSender.cs
@@ -6,7 +6,6 @@ namespace Masa.Mc.Infrastructure.AppNotification.Getui;
 public class GetuiSender : IAppNotificationSender
 {
     private readonly IOptionsResolver<IGetuiOptions> _optionsResolver;
-    private static string HOST = "http://api.getui.com/apiex.htm";
 
     public GetuiSender(IOptionsResolver<IGetuiOptions> optionsResolver)
     {
@@ -16,7 +15,7 @@ public class GetuiSender : IAppNotificationSender
     public async Task<AppNotificationResponseBase> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default)
     {
         var options = await _optionsResolver.ResolveAsync();
-        IGtPush push = new IGtPush(HOST, options.AppKey, options.MasterSecret);
+        IGtPush push = new IGtPush(GetuiConstants.DomainUrl, options.AppKey, options.MasterSecret);
         NotificationTemplate template = NotificationTemplate(options, appMessage.Title, appMessage.Text, System.Text.Json.JsonSerializer.Serialize(appMessage.TransmissionContent));
 
         SingleMessage message = new SingleMessage();
@@ -47,7 +46,7 @@ public class GetuiSender : IAppNotificationSender
     public async Task<AppNotificationResponseBase> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default)
     {
         var options = await _optionsResolver.ResolveAsync();
-        IGtPush push = new IGtPush(HOST, options.AppKey, options.MasterSecret);
+        IGtPush push = new IGtPush(GetuiConstants.DomainUrl, options.AppKey, options.MasterSecret);
         NotificationTemplate template = NotificationTemplate(options, appMessage.Title, appMessage.Text, System.Text.Json.JsonSerializer.Serialize(appMessage.TransmissionContent));
 
         com.igetui.api.openservice.igetui.AppMessage message = new com.igetui.api.openservice.igetui.AppMessage();

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
@@ -67,6 +67,15 @@ public class HuaweiPushSender : IAppNotificationSender
         return Task.FromResult(new AppNotificationResponseBase(false, "Withdrawal operation not supported"));
     }
 
+    private object BuildClickAction(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return new { type = 3 };
+        if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            return new { type = 2, url };
+        return new { type = 1, action = url };
+    }
+
     private HmsPushRequest BuildMessagePayload(AppMessage message, string[]? tokens = null, string? topic = null)
     {
         return new HmsPushRequest
@@ -81,11 +90,7 @@ public class HuaweiPushSender : IAppNotificationSender
                 {
                     Notification = new HmsAndroidNotification
                     {
-                        ClickAction = new
-                        {
-                            type = string.IsNullOrEmpty(message.Url) ? (int)ClickActionType.OpenApp : (int)ClickActionType.AppDefinedIntent,
-                            intent = message.Url
-                        }
+                        ClickAction = BuildClickAction(message.Url)
                     }
                 }
             }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/IOppoPushOptions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/IOppoPushOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public interface IOppoPushOptions : IOptions
+{
+    public string AppKey { get; set; }
+
+    public string MasterSecret { get; set; }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoAuthService.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoAuthService.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public class OppoAuthService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ICacheContext _cacheContext;
+
+    public OppoAuthService(HttpClient httpClient, ICacheContext cacheContext)
+    {
+        _httpClient = httpClient;
+        _cacheContext = cacheContext;
+    }
+
+    public async Task<string> GetAccessTokenAsync(string appKey, string masterSecret, CancellationToken ct)
+    {
+        var cacheKey = $"oppo:access_token:{appKey}";
+
+        return await _cacheContext.GetOrSetAsync(cacheKey, async () =>
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var timestamp = now;
+            var sign = GenerateSign(appKey, masterSecret, timestamp);
+
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "app_key", appKey },
+                { "sign", sign },
+                { "timestamp", timestamp.ToString() }
+            });
+
+            var response = await _httpClient.PostAsync(OppoConstants.AuthUrl, content, ct);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var token = doc.RootElement.GetProperty("data").GetProperty("auth_token").GetString()!;
+            // OPPO official documentation states the validity period is 24 hours, it is recommended to refresh 1 hour in advance
+            var cacheEntryOptions = new CacheEntryOptions(TimeSpan.FromHours(23));
+            return (token, cacheEntryOptions);
+        });
+    }
+
+    private string GenerateSign(string appKey, string masterSecret, long timestamp)
+    {
+        var raw = appKey + timestamp + masterSecret;
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(raw);
+        var hash = sha256.ComputeHash(bytes);
+        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoConstants.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public static class OppoConstants
+{
+    public const string AuthUrl = "https://api.push.oppomobile.com/server/v1/auth";
+    public const string UnicastUrl = "https://api.push.oppomobile.com/server/v1/message/notification/unicast";
+    public const string UnicastBatchUrl = "https://api.push.oppomobile.com/server/v1/message/notification/unicast_batch";
+    public const string SaveMessageContentUrl = "https://api.push.oppomobile.com/server/v1/message/notification/save_message_content";
+    public const string BroadcastUrl = "https://api.push.oppomobile.com/server/v1/message/notification/broadcast";
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushOptions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public class OppoPushOptions: IOppoPushOptions
+{
+    public string AppKey { get; set; } = string.Empty;
+
+    public string MasterSecret { get; set; } = string.Empty;
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushOptionsResolver.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushOptionsResolver.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public class OppoPushOptionsResolver : IOptionsResolver<IOppoPushOptions>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ResolveOptions<IOppoPushOptions> _options;
+
+    public OppoPushOptionsResolver(IServiceProvider serviceProvider,
+        IOptions<ResolveOptions<IOppoPushOptions>> resolveOptions)
+    {
+        _serviceProvider = serviceProvider;
+        _options = resolveOptions.Value;
+    }
+
+    public async Task<IOppoPushOptions> ResolveAsync()
+    {
+        using (var serviceScope = _serviceProvider.CreateScope())
+        {
+            var context = new OptionsResolveContext<IOppoPushOptions>(serviceScope.ServiceProvider);
+
+            foreach (var resolver in _options.Contributors)
+            {
+                await resolver.ResolveAsync(context);
+
+                if (context.Options != null)
+                {
+                    return context.Options;
+                }
+            }
+        }
+
+        return new OppoPushOptions();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public class OppoPushSender : IAppNotificationSender
+{
+    private readonly HttpClient _httpClient;
+    private readonly OppoAuthService _authService;
+    private readonly IOptionsResolver<IOppoPushOptions> _optionsResolver;
+
+    public OppoPushSender(HttpClient httpClient, OppoAuthService authService, IOptionsResolver<IOppoPushOptions> optionsResolver)
+    {
+        _httpClient = httpClient;
+        _authService = authService;
+        _optionsResolver = optionsResolver;
+    }
+
+    public async Task<AppNotificationResponseBase> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options.AppKey, options.MasterSecret, ct);
+
+        var messageObj = new
+        {
+            target_type = 2,
+            target_value = appMessage.ClientId,
+            verify_registration_id = true,
+            notification = BuildNotification(appMessage)
+        };
+
+        var form = new Dictionary<string, string>
+        {
+            { "auth_token", token },
+            { "message", JsonSerializer.Serialize(messageObj) }
+        };
+
+        var content = new FormUrlEncodedContent(form);
+        var response = await _httpClient.PostAsync(OppoConstants.UnicastUrl, content, ct);
+        return await HandleResponse(response, ct);
+    }
+
+    public async Task<AppNotificationResponseBase> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default)
+    {
+        if (appMessage.ClientIds.Length > 1000)
+            return new AppNotificationResponseBase(false, "Up to 1000 device tokens can be sent at a time");
+
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options.AppKey, options.MasterSecret, ct);
+
+        var messages = appMessage.ClientIds.Select(id => new
+        {
+            target_type = 2,
+            target_value = id,
+            notification = BuildNotification(appMessage)
+        }).ToArray();
+
+        var form = new Dictionary<string, string>
+        {
+            { "auth_token", token },
+            { "messages", JsonSerializer.Serialize(messages) }
+        };
+
+        var content = new FormUrlEncodedContent(form);
+        var response = await _httpClient.PostAsync(OppoConstants.UnicastBatchUrl, content, ct);
+        return await HandleResponse(response, ct);
+    }
+
+    private Dictionary<string, object?> BuildNotification(AppMessage appMessage)
+    {
+        var notification = new Dictionary<string, object?>
+        {
+            { "app_message_id", Guid.NewGuid().ToString("N") },
+            { "title", appMessage.Title },
+            { "content", appMessage.Text },
+            { "off_line_ttl", 86400 }
+        };
+
+        if (appMessage.Url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            notification["click_action_type"] = 2;
+            notification["click_action_url"] = appMessage.Url;
+        }
+        else if(!string.IsNullOrEmpty(appMessage.Url))
+        {
+            notification["click_action_type"] = 1;
+            notification["click_action_activity"] = appMessage.Url;
+        }
+
+        return notification;
+    }
+
+    private async Task<string> SaveBroadcastMessageAsync(AppMessage appMessage, string authToken, CancellationToken ct)
+    {
+        var notification = BuildNotification(appMessage);
+        var form = notification.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString() ?? string.Empty);
+        form["auth_token"] = authToken;
+
+        var content = new FormUrlEncodedContent(form);
+        var response = await _httpClient.PostAsync(OppoConstants.SaveMessageContentUrl, content, ct);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("data").GetProperty("message_id").GetString()!;
+    }
+
+    public async Task<AppNotificationResponseBase> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options.AppKey, options.MasterSecret, ct);
+        var messageId = await SaveBroadcastMessageAsync(appMessage, token, ct);
+
+        var form = new Dictionary<string, string>
+        {
+            { "auth_token", token },
+            { "message_id", messageId },
+            { "target_type", "6" },
+            { "target_value", "all" }
+        };
+        var content = new FormUrlEncodedContent(form);
+        var response = await _httpClient.PostAsync(OppoConstants.BroadcastUrl, content, ct);
+        return await HandleResponse(response, ct);
+    }
+
+    public Task<AppNotificationResponseBase> WithdrawnAsync(string msgId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponseBase(false, "OPPO Push does not support message withdrawal"));
+
+    private async Task<AppNotificationResponseBase> HandleResponse(HttpResponseMessage response, CancellationToken ct)
+    {
+        var json = await response.Content.ReadAsStringAsync(ct);
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var code = doc.RootElement.GetProperty("code").GetInt32();
+            var message = doc.RootElement.GetProperty("message").GetString() ?? "";
+            var msgId = doc.RootElement.TryGetProperty("data", out var data) && data.TryGetProperty("message_id", out var idProp) ? idProp.GetString() ?? "" : "";
+
+            if (code == 0)
+                return new AppNotificationResponseBase(true, "Push succeeded", msgId);
+            else
+                return new AppNotificationResponseBase(false, $"Push failed: {message}");
+        }
+        catch
+        {
+            return new AppNotificationResponseBase(false, $"Push failed: {json}");
+        }
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoSenderProvider.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoSenderProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public class OppoSenderProvider : IAppNotificationSenderProvider
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public Providers Provider => Providers.Oppo;
+
+    public OppoSenderProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public IOptions ResolveOptions(ConcurrentDictionary<string, object> extraProperties)
+    {
+        return PushOptionsMapper.Map<OppoPushOptions>(extraProperties);
+    }
+
+    public IProviderAsyncLocalBase ResolveProviderAsyncLocal()
+    {
+        return _serviceProvider.GetRequiredService<IProviderAsyncLocal<IOppoPushOptions>>();
+    }
+
+    public IAppNotificationSender ResolveSender()
+    {
+        return _serviceProvider.GetRequiredService<OppoPushSender>();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Providers.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Providers.cs
@@ -8,5 +8,6 @@ public enum Providers
     GeTui = 1,
     JPush,
     Huawei,
-    Xiaomi
+    Xiaomi,
+    Oppo
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
         services.AddJPush();
         services.AddHuaweiPush();
         services.AddXiaomiPush();
+        services.AddOppoPush();
         services.TryAddTransient<AppNotificationSenderFactory>();
         return services;
     }
@@ -31,6 +32,13 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddXiaomiPush(this IServiceCollection services) =>
         services.AddPushProvider<IXiaomiPushOptions, XiaomiPushOptionsResolver, XiaomiPushSender, XiaomiSenderProvider>();
+
+    public static IServiceCollection AddOppoPush(this IServiceCollection services)
+    {
+        services.AddPushProvider<IOppoPushOptions, OppoPushOptionsResolver, OppoPushSender, OppoSenderProvider>();
+        services.AddScoped<OppoAuthService>();
+        return services;
+    }
 
     public static IServiceCollection AddPushProvider<TOptions, TOptionsResolver, TSender, TSenderProvider>(
     this IServiceCollection services)

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiPushSender.cs
@@ -61,7 +61,12 @@ public class XiaomiPushSender : IAppNotificationSender
             payload["registration_id"] = clientId;
         }
 
-        if (!string.IsNullOrEmpty(url))
+        if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            payload["extra.notify_effect"] = "3";
+            payload["extra.web_uri"] = url;
+        }
+        else if (!string.IsNullOrEmpty(url))
         {
             payload["extra.notify_effect"] = "2";
             payload["extra.intent_uri"] = url;

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
@@ -27,3 +27,5 @@ global using Masa.Contrib.Caching.Distributed.StackExchangeRedis;
 global using System.Linq.Expressions;
 global using System.Net.Http.Headers;
 global using Masa.Mc.Infrastructure.AppNotification.Xiaomi;
+global using System.Text;
+global using Masa.Mc.Infrastructure.AppNotification.Oppo;


### PR DESCRIPTION
Added OPPO push service related functions, including 'OppoPushSender', 'OppoAuthService', 'OppoPushOptions' and other categories, which support unicast, batch unicast and broadcast push. Add the 'Oppo' option in the 'Providers' enumeration, and add the' AddOppoPush 'method in the' ServiceCollectionExtensions' to support dependency injection.

Optimize the Getui and Huawei push logic:
-Replace the URL hard code of Getui with the constant 'GetuiConstants. DomainUrl'.
-Reconstruct Huawei's click operation logic to improve code reusability.

New global references and constant classes are added to uniformly manage configuration and improve code maintainability.