### PR TITLE
refactor: Support Vivo push service and optimize broadcast push logic

### DIFF
--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/AppNotificationConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/AppNotificationConstants.cs
@@ -3,12 +3,7 @@
 
 namespace Masa.Mc.Infrastructure.AppNotification;
 
-public enum Providers
+public static class AppNotificationConstants
 {
-    GeTui = 1,
-    JPush,
-    Huawei,
-    Xiaomi,
-    Oppo,
-    Vivo
+    public const string BroadcastTag = "all";
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
@@ -53,7 +53,7 @@ public class HuaweiPushSender : IAppNotificationSender
         var accessToken = await _oauthService.GetAccessTokenAsync(options.ClientId, options.ClientSecret, ct);
         var url = string.Format(HuaweiConstants.PushMessageUrlFormat, options.ProjectId);
 
-        var payload = BuildMessagePayload(message, null, "all");
+        var payload = BuildMessagePayload(message, null, AppNotificationConstants.BroadcastTag);
 
         var request = CreatePushRequest(url, payload, accessToken);
 

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/JPush/JPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/JPush/JPushSender.cs
@@ -79,7 +79,7 @@ public class JPushSender : IAppNotificationSender
         var options = await _optionsResolver.ResolveAsync();
         JPushClient client = new JPushClient(options.AppKey, options.MasterSecret);
 
-        var pushPayload = GetPushPayload(appMessage, "all");
+        var pushPayload = GetPushPayload(appMessage, AppNotificationConstants.BroadcastTag);
 
         try
         {

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
@@ -25,7 +25,7 @@ public class OppoPushSender : IAppNotificationSender
 
         var messageObj = new
         {
-            target_type = 2,
+            target_type = OppoTargetType.RegistrationId,
             target_value = appMessage.ClientId,
             verify_registration_id = true,
             notification = BuildNotification(appMessage)
@@ -52,7 +52,7 @@ public class OppoPushSender : IAppNotificationSender
 
         var messages = appMessage.ClientIds.Select(id => new
         {
-            target_type = 2,
+            target_type = OppoTargetType.RegistrationId,
             target_value = id,
             notification = BuildNotification(appMessage)
         }).ToArray();
@@ -116,7 +116,7 @@ public class OppoPushSender : IAppNotificationSender
         {
             { "auth_token", token },
             { "message_id", messageId },
-            { "target_type", "6" },
+            { "target_type", ((int)OppoTargetType.Tag).ToString() },
             { "target_value", AppNotificationConstants.BroadcastTag }
         };
         var content = new FormUrlEncodedContent(form);

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
@@ -117,7 +117,7 @@ public class OppoPushSender : IAppNotificationSender
             { "auth_token", token },
             { "message_id", messageId },
             { "target_type", "6" },
-            { "target_value", "all" }
+            { "target_value", AppNotificationConstants.BroadcastTag }
         };
         var content = new FormUrlEncodedContent(form);
         var response = await _httpClient.PostAsync(OppoConstants.BroadcastUrl, content, ct);

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoTargetType.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoTargetType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Oppo;
+
+public enum OppoTargetType
+{
+    RegistrationId = 2,
+    Alias = 5,
+    Tag = 6
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class ServiceCollectionExtensions
         services.AddHuaweiPush();
         services.AddXiaomiPush();
         services.AddOppoPush();
+        services.AddVivoPush();
         services.TryAddTransient<AppNotificationSenderFactory>();
         return services;
     }
@@ -37,6 +38,13 @@ public static class ServiceCollectionExtensions
     {
         services.AddPushProvider<IOppoPushOptions, OppoPushOptionsResolver, OppoPushSender, OppoSenderProvider>();
         services.AddScoped<OppoAuthService>();
+        return services;
+    }
+
+    public static IServiceCollection AddVivoPush(this IServiceCollection services)
+    {
+        services.AddPushProvider<IVivoPushOptions, VivoPushOptionsResolver, VivoPushSender, VivoSenderProvider>();
+        services.AddScoped<VivoAuthService>();
         return services;
     }
 

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/IVivoPushOptions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/IVivoPushOptions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public interface IVivoPushOptions : IOptions
+{
+    public string AppId { get; set; }
+
+    public string AppKey { get; set; }
+
+    public string AppSecret { get; set; }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoAuthService.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoAuthService.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public class VivoAuthService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ICacheContext _cacheContext;
+
+    public VivoAuthService(HttpClient httpClient, ICacheContext cacheContext)
+    {
+        _httpClient = httpClient;
+        _cacheContext = cacheContext;
+    }
+
+    public async Task<string> GetAccessTokenAsync(IVivoPushOptions options, CancellationToken ct = default)
+    {
+        var cacheKey = $"vivo:access_token:{options.AppId}";
+        return await _cacheContext.GetOrSetAsync(cacheKey, async () =>
+        {
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var sign = GenerateSign(options.AppId, options.AppKey, timestamp, options.AppSecret);
+            var payload = new
+            {
+                appId = options.AppId,
+                appKey = options.AppKey,
+                timestamp,
+                sign
+            };
+            var request = new HttpRequestMessage(HttpMethod.Post, VivoConstants.AuthUrl)
+            {
+                Content = JsonContent.Create(payload)
+            };
+            var response = await _httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var token = doc.RootElement.GetProperty("authToken").GetString()!;
+            var cacheEntryOptions = new CacheEntryOptions(TimeSpan.FromHours(23));
+            return (token, cacheEntryOptions);
+        });
+    }
+
+    private string GenerateSign(string appId, string appKey, long timestamp, string appSecret)
+    {
+        var raw = $"{appId}{appKey}{timestamp}{appSecret}";
+        using var md5 = System.Security.Cryptography.MD5.Create();
+        var bytes = Encoding.UTF8.GetBytes(raw);
+        var hash = md5.ComputeHash(bytes);
+        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoConstants.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public static class VivoConstants
+{
+    public const string AuthUrl = "https://api-push.vivo.com.cn/message/auth";
+    public const string SendUrl = "https://api-push.vivo.com.cn/message/send";
+    public const string SaveListPayloadUrl = "https://api-push.vivo.com.cn/message/saveListPayload";
+    public const string PushToListUrl = "https://api-push.vivo.com.cn/message/pushToList";
+    public const string TagPushUrl = "https://api-push.vivo.com.cn/message/tagPush";
+    public const string RecycleUrl = "https://api-push.vivo.com.cn/message/recycle";
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushOptions.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushOptions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public class VivoPushOptions: IVivoPushOptions
+{
+    public string AppId { get; set; } = string.Empty;
+
+    public string AppKey { get; set; } = string.Empty;
+
+    public string AppSecret { get; set; } = string.Empty;
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushOptionsResolver.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushOptionsResolver.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public class VivoPushOptionsResolver : IOptionsResolver<IVivoPushOptions>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ResolveOptions<IVivoPushOptions> _options;
+
+    public VivoPushOptionsResolver(IServiceProvider serviceProvider,
+        IOptions<ResolveOptions<IVivoPushOptions>> resolveOptions)
+    {
+        _serviceProvider = serviceProvider;
+        _options = resolveOptions.Value;
+    }
+
+    public async Task<IVivoPushOptions> ResolveAsync()
+    {
+        using (var serviceScope = _serviceProvider.CreateScope())
+        {
+            var context = new OptionsResolveContext<IVivoPushOptions>(serviceScope.ServiceProvider);
+
+            foreach (var resolver in _options.Contributors)
+            {
+                await resolver.ResolveAsync(context);
+
+                if (context.Options != null)
+                {
+                    return context.Options;
+                }
+            }
+        }
+
+        return new VivoPushOptions();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoPushSender.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public class VivoPushSender : IAppNotificationSender
+{
+    private readonly HttpClient _httpClient;
+    private readonly IOptionsResolver<IVivoPushOptions> _optionsResolver;
+    private readonly VivoAuthService _authService;
+
+    public VivoPushSender(HttpClient httpClient, IOptionsResolver<IVivoPushOptions> optionsResolver, VivoAuthService authService)
+    {
+        _httpClient = httpClient;
+        _optionsResolver = optionsResolver;
+        _authService = authService;
+    }
+
+    public async Task<AppNotificationResponseBase> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default)
+    {
+        var payload = await CreatePayloadAsync(appMessage, ct);
+        return await SendWithResolvedOptionsAsync(VivoConstants.SendUrl, payload, ct);
+    }
+
+    public async Task<AppNotificationResponseBase> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default)
+    {
+        if (appMessage.ClientIds.Length < 2 || appMessage.ClientIds.Length > 1000)
+            return new AppNotificationResponseBase(false, "regIds count must be 2~1000");
+
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options, ct);
+
+        var savePayload = await CreatePayloadAsync(appMessage, ct);
+        var saveResponse = await SendRequestAsync(VivoConstants.SaveListPayloadUrl, savePayload, token, ct);
+        if (!saveResponse.Success) return saveResponse;
+
+        var pushPayload = await CreatePayloadAsync(appMessage, ct, null, appMessage.ClientIds, saveResponse.MsgId);
+        return await SendRequestAsync(VivoConstants.PushToListUrl, pushPayload, token, ct);
+    }
+
+    public async Task<AppNotificationResponseBase> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default)
+    {
+        var payload = await CreatePayloadAsync(appMessage, ct, new { orTags = new[] { AppNotificationConstants.BroadcastTag } });
+        return await SendWithResolvedOptionsAsync(VivoConstants.TagPushUrl, payload, ct);
+    }
+
+    public async Task<AppNotificationResponseBase> WithdrawnAsync(string msgId, CancellationToken ct = default)
+    {
+        var payload = new
+        {
+            appId = (await _optionsResolver.ResolveAsync()).AppId,
+            taskId = msgId,
+            userIds = Array.Empty<string>(),
+            userType = 1
+        };
+        return await SendWithResolvedOptionsAsync(VivoConstants.RecycleUrl, payload, ct);
+    }
+
+    private async Task<AppNotificationResponseBase> SendWithResolvedOptionsAsync(string url, object payload, CancellationToken ct)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options, ct);
+        return await SendRequestAsync(url, payload, token, ct);
+    }
+
+    private async Task<AppNotificationResponseBase> SendRequestAsync(string url, object payload, string? token = null, CancellationToken ct = default)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(payload)
+        };
+        if (!string.IsNullOrEmpty(token))
+            request.Headers.Add("authToken", token);
+
+        var response = await _httpClient.SendAsync(request, ct);
+        return await HandleResponse(response, ct);
+    }
+
+    private int BuildSkipType(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return 1;
+        if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            return 2;
+        return 3;
+    }
+
+    private async Task<object> CreatePayloadAsync(AppMessage appMessage, CancellationToken ct, object? tagExpression = null, string[]? regIds = null, string? taskId = null)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+
+        return new
+        {
+            appId = options.AppId,
+            regId = appMessage is SingleAppMessage single ? single.ClientId : null,
+            regIds,
+            tagExpression,
+            taskId,
+            notifyType = 4,
+            title = appMessage.Title,
+            content = appMessage.Text,
+            skipType = BuildSkipType(appMessage.Url),
+            skipContent = appMessage.Url,
+            requestId = Guid.NewGuid().ToString("N")
+        };
+    }
+
+    private async Task<AppNotificationResponseBase> HandleResponse(HttpResponseMessage response, CancellationToken ct)
+    {
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var result = doc.RootElement.GetProperty("result").GetInt32();
+        var desc = doc.RootElement.GetProperty("desc").GetString() ?? "";
+        var taskId = doc.RootElement.TryGetProperty("taskId", out var idProp) ? idProp.GetString() ?? "" : "";
+        return result == 0
+            ? new AppNotificationResponseBase(true, "Push succeeded", taskId)
+            : new AppNotificationResponseBase(false, $"Push failed: {desc}");
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoSenderProvider.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoSenderProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Infrastructure.AppNotification.Vivo;
+
+public class VivoSenderProvider : IAppNotificationSenderProvider
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public Providers Provider => Providers.Vivo;
+
+    public VivoSenderProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public IOptions ResolveOptions(ConcurrentDictionary<string, object> extraProperties)
+    {
+        return PushOptionsMapper.Map<VivoPushOptions>(extraProperties);
+    }
+
+    public IProviderAsyncLocalBase ResolveProviderAsyncLocal()
+    {
+        return _serviceProvider.GetRequiredService<IProviderAsyncLocal<IVivoPushOptions>>();
+    }
+
+    public IAppNotificationSender ResolveSender()
+    {
+        return _serviceProvider.GetRequiredService<VivoPushSender>();
+    }
+}

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
@@ -29,3 +29,4 @@ global using System.Net.Http.Headers;
 global using Masa.Mc.Infrastructure.AppNotification.Xiaomi;
 global using System.Text;
 global using Masa.Mc.Infrastructure.AppNotification.Oppo;
+global using Masa.Mc.Infrastructure.AppNotification.Vivo;


### PR DESCRIPTION
New support for Vivo push service, including configuration, authentication and sending logic:
-A new 'VivoPushSender' is added, which supports single, batch, broadcast push and message recall.
-Add 'VivoAuthService' to process signature generation and access token acquisition.
-Add 'VivoPushOptions' and parser to manage push service configuration.
-Add 'VivoConstants' to define related URL constants.
-Add an 'AddVivoPush' extension method to register the Vivo push dependency.

Optimize broadcast push logic:
-Change the broadcast target value from hard coded 'all' to constant 'BroadcastTag'.
-Add 'AppNotificationConstants' and define' BroadcastTag 'constants.

Other changes:
-Add 'Vivo' push service enumeration value in 'Providers'.
-Add a global reference to the 'Vivo' push service in '_Imports'.