### PR TITLE
refactor: Unify notification response model and optimize push logic

### DIFF
--- a/src/Domain/Masa.Mc.Domain.Shared/MessageTasks/MessageSendStatuses.cs
+++ b/src/Domain/Masa.Mc.Domain.Shared/MessageTasks/MessageSendStatuses.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Domain.Shared.MessageTasks;
+
+public enum MessageSendStatuses
+{
+    Success = 1,
+    Fail,
+    PartialFailure
+}

--- a/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageReceiverUser.cs
+++ b/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageReceiverUser.cs
@@ -11,10 +11,13 @@ public class MessageReceiverUser : ValueObject
 
     public ExtraPropertyDictionary Variables { get; set; } = new();
 
+    public string Platform { get; set; } = string.Empty;
+
     protected override IEnumerable<object> GetEqualityValues()
     {
         yield return UserId;
         yield return ChannelUserIdentity;
+        yield return Platform;
 
         foreach (var variable in Variables.OrderBy(x => x.Key))
         {
@@ -25,10 +28,11 @@ public class MessageReceiverUser : ValueObject
 
     private MessageReceiverUser() { }
 
-    public MessageReceiverUser(Guid userId, string channelUserIdentity, ExtraPropertyDictionary variables)
+    public MessageReceiverUser(Guid userId, string channelUserIdentity, ExtraPropertyDictionary variables, string platform = "")
     {
         UserId = userId;
         ChannelUserIdentity = channelUserIdentity;
         Variables = variables;
+        Platform = platform;
     }
 }

--- a/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTask.cs
+++ b/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTask.cs
@@ -186,5 +186,5 @@ public class MessageTask : FullAggregateRoot<Guid, Guid>
 
     public string IsApnsProduction => ExtraProperties.GetProperty<string>(BusinessConsts.IS_APNS_PRODUCTION);
 
-    public bool IsUniformContent => !Receivers.Any(x => x.Variables.Any());
+    public bool IsUniformContent => EntityType == MessageEntityTypes.Ordinary || !Receivers.Any(x => x.Variables.Any());
 }

--- a/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTask.cs
+++ b/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTask.cs
@@ -180,27 +180,11 @@ public class MessageTask : FullAggregateRoot<Guid, Guid>
         return receiverUsers.Skip(historyNum * sendingCount).Take(sendingCount).ToList(); ;
     }
 
-    public bool IsAppInWebsiteMessage
-    {
-        get
-        {
-            return ChannelType?.Id == ChannelType.App.Id && ExtraProperties.GetProperty<bool>(BusinessConsts.IS_WEBSITE_MESSAGE);
-        }
-    }
+    public bool IsAppInWebsiteMessage => ChannelType?.Id == ChannelType.App.Id && ExtraProperties.GetProperty<bool>(BusinessConsts.IS_WEBSITE_MESSAGE);
 
-    public string AppIntentUrl
-    {
-        get
-        {
-            return ExtraProperties.GetProperty<string>(BusinessConsts.INTENT_URL);
-        }
-    }
+    public string AppIntentUrl => ExtraProperties.GetProperty<string>(BusinessConsts.INTENT_URL);
 
-    public string IsApnsProduction
-    {
-        get
-        {
-            return ExtraProperties.GetProperty<string>(BusinessConsts.IS_APNS_PRODUCTION);
-        }
-    }
+    public string IsApnsProduction => ExtraProperties.GetProperty<string>(BusinessConsts.IS_APNS_PRODUCTION);
+
+    public bool IsUniformContent => !Receivers.Any(x => x.Variables.Any());
 }

--- a/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTaskHistory.cs
+++ b/src/Domain/Masa.Mc.Domain/MessageTasks/Aggregates/MessageTaskHistory.cs
@@ -88,6 +88,19 @@ public class MessageTaskHistory : FullAggregateRoot<Guid, Guid>
         }
     }
 
+    public void SetResult(MessageSendStatuses status)
+    {
+        var mappedStatus = status switch
+        {
+            MessageSendStatuses.Success => MessageTaskHistoryStatuses.Success,
+            MessageSendStatuses.Fail => MessageTaskHistoryStatuses.Fail,
+            MessageSendStatuses.PartialFailure => MessageTaskHistoryStatuses.PartialFailure,
+            _ => throw new ArgumentException($"Unsupported MessageSendStatuses: {status}", nameof(status))
+        };
+
+        SetResult(mappedStatus);
+    }
+
     public void SetTaskId(Guid taskId)
     {
         SchedulerTaskId = taskId;

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250612073114_AddMessageReceiverUserPlatform.Designer.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250612073114_AddMessageReceiverUserPlatform.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Masa.Mc.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Masa.Mc.EntityFrameworkCore.PostgreSql.Migrations
 {
     [DbContext(typeof(McDbContext))]
-    partial class McDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250612073114_AddMessageReceiverUserPlatform")]
+    partial class AddMessageReceiverUserPlatform
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250612073114_AddMessageReceiverUserPlatform.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250612073114_AddMessageReceiverUserPlatform.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Masa.Mc.EntityFrameworkCore.PostgreSql.Migrations
+{
+    public partial class AddMessageReceiverUserPlatform : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Platform",
+                table: "MessageReceiverUsers",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Platform",
+                table: "MessageReceiverUsers");
+        }
+    }
+}

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore/McDbContextModelBuilderExtensions.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore/McDbContextModelBuilderExtensions.cs
@@ -128,6 +128,7 @@ public static class McDbContextModelBuilderExtensions
             b.Property<Guid>("Id").ValueGeneratedOnAdd();
             b.HasKey("Id");
             b.Property(x => x.ChannelUserIdentity).IsRequired().HasMaxLength(128);
+            b.Property(x => x.Platform).IsRequired().HasMaxLength(128);
             b.Property(x => x.Variables).HasConversion(new ExtraPropertiesValueConverter()).Metadata.SetValueComparer(new ExtraPropertyDictionaryValueComparer());
         });
 

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HmsPushRequest.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HmsPushRequest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
-using System.Text.Json.Serialization;
-
 namespace Masa.Mc.Infrastructure.AppNotification.Huawei;
 
 public class HmsPushRequest

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HmsPushRequest.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HmsPushRequest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) MASA Stack All rights reserved.
 // Licensed under the Apache License. See LICENSE.txt in the project root for license information.
 
+using System.Text.Json.Serialization;
+
 namespace Masa.Mc.Infrastructure.AppNotification.Huawei;
 
 public class HmsPushRequest
@@ -40,5 +42,7 @@ public class HmsAndroidNotification
     public string Sound { get; set; }
     public bool DefaultSound { get; set; }
     public string Importance { get; set; } = "NORMAL";
+
+    [JsonPropertyName("click_action")]
     public object ClickAction { get; set; }
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
@@ -135,5 +135,4 @@ public class HuaweiPushSender : IAppNotificationSender
         var error = await response.Content.ReadAsStringAsync(ct);
         return new AppNotificationResponse(false, $"Push failed: HTTP {response.StatusCode} - {error}");
     }
-
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
@@ -58,7 +58,7 @@ public class HuaweiPushSender : IAppNotificationSender
         var request = CreatePushRequest(url, payload, accessToken);
 
         var response = await _httpClient.SendAsync(request, ct);
-        return await HandleResponse(response, ct, true);
+        return await HandleResponse(response, ct);
     }
 
     public Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default)
@@ -107,7 +107,7 @@ public class HuaweiPushSender : IAppNotificationSender
         return request;
     }
 
-    private async Task<AppNotificationResponse> HandleResponse(HttpResponseMessage response, CancellationToken ct, bool isBatch = false)
+    private async Task<AppNotificationResponse> HandleResponse(HttpResponseMessage response, CancellationToken ct)
     {
         if (response.IsSuccessStatusCode)
         {
@@ -120,7 +120,7 @@ public class HuaweiPushSender : IAppNotificationSender
             {
                 return new AppNotificationResponse(true, "Success", requestId);
             }
-            else if (code == "80100000" && isBatch)
+            else if (code == "80100000")
             {
                 var illegalTokens = result.GetProperty("msg").GetProperty("illegal_tokens")
                     .EnumerateArray().Select(t => t.GetString() ?? string.Empty).ToList();

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiPushSender.cs
@@ -16,7 +16,7 @@ public class HuaweiPushSender : IAppNotificationSender
         _optionsResolver = optionsResolver;
     }
 
-    public async Task<AppNotificationResponseBase> SendAsync(SingleAppMessage message, CancellationToken ct = default)
+    public async Task<AppNotificationResponse> SendAsync(SingleAppMessage message, CancellationToken ct = default)
     {
         var options = await _optionsResolver.ResolveAsync();
         var accessToken = await _oauthService.GetAccessTokenAsync(options.ClientId, options.ClientSecret, ct);
@@ -30,10 +30,10 @@ public class HuaweiPushSender : IAppNotificationSender
         return await HandleResponse(response, ct);
     }
 
-    public async Task<AppNotificationResponseBase> BatchSendAsync(BatchAppMessage message, CancellationToken ct = default)
+    public async Task<AppNotificationResponse> BatchSendAsync(BatchAppMessage message, CancellationToken ct = default)
     {
         if (message.ClientIds.Length > 1000)
-            return new AppNotificationResponseBase(false, "Up to 1000 device tokens can be sent at a time");
+            return new AppNotificationResponse(false, "Up to 1000 device tokens can be sent at a time");
 
         var options = await _optionsResolver.ResolveAsync();
         var accessToken = await _oauthService.GetAccessTokenAsync(options.ClientId, options.ClientSecret, ct);
@@ -47,7 +47,7 @@ public class HuaweiPushSender : IAppNotificationSender
         return await HandleResponse(response, ct);
     }
 
-    public async Task<AppNotificationResponseBase> BroadcastSendAsync(AppMessage message, CancellationToken ct = default)
+    public async Task<AppNotificationResponse> BroadcastSendAsync(AppMessage message, CancellationToken ct = default)
     {
         var options = await _optionsResolver.ResolveAsync();
         var accessToken = await _oauthService.GetAccessTokenAsync(options.ClientId, options.ClientSecret, ct);
@@ -58,13 +58,13 @@ public class HuaweiPushSender : IAppNotificationSender
         var request = CreatePushRequest(url, payload, accessToken);
 
         var response = await _httpClient.SendAsync(request, ct);
-        return await HandleResponse(response, ct);
+        return await HandleResponse(response, ct, true);
     }
 
-    public Task<AppNotificationResponseBase> WithdrawnAsync(string msgId, CancellationToken ct = default)
+    public Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default)
     {
         // Huawei Push V1/V2 does not support message withdrawal  
-        return Task.FromResult(new AppNotificationResponseBase(false, "Withdrawal operation not supported"));
+        return Task.FromResult(new AppNotificationResponse(false, "Withdrawal operation not supported"));
     }
 
     private object BuildClickAction(string url)
@@ -107,7 +107,7 @@ public class HuaweiPushSender : IAppNotificationSender
         return request;
     }
 
-    private async Task<AppNotificationResponseBase> HandleResponse(HttpResponseMessage response, CancellationToken ct)
+    private async Task<AppNotificationResponse> HandleResponse(HttpResponseMessage response, CancellationToken ct, bool isBatch = false)
     {
         if (response.IsSuccessStatusCode)
         {
@@ -118,21 +118,22 @@ public class HuaweiPushSender : IAppNotificationSender
 
             if (code == "80000000")
             {
-                return new AppNotificationResponseBase(true, "Success", requestId);
+                return new AppNotificationResponse(true, "Success", requestId);
             }
-            else if (code == "80100000")
+            else if (code == "80100000" && isBatch)
             {
-                // Some tokens are invalid  
-                var illegalTokens = result.GetProperty("msg").GetProperty("illegal_tokens").EnumerateArray().Select(t => t.GetString()).ToList();
-                return new AppNotificationResponseBase(false, $"Some tokens are invalid: {string.Join(",", illegalTokens)}", requestId);
+                var illegalTokens = result.GetProperty("msg").GetProperty("illegal_tokens")
+                    .EnumerateArray().Select(t => t.GetString() ?? string.Empty).ToList();
+                return new AppNotificationResponse(true, $"Some tokens are invalid: {string.Join(",", illegalTokens)}", requestId, illegalTokens);
             }
             else
             {
-                return new AppNotificationResponseBase(false, $"Push failed: {msg}", requestId);
+                return new AppNotificationResponse(false, $"Push failed: {msg}", requestId);
             }
         }
 
         var error = await response.Content.ReadAsStringAsync(ct);
-        return new AppNotificationResponseBase(false, $"Push failed: HTTP {response.StatusCode} - {error}");
+        return new AppNotificationResponse(false, $"Push failed: HTTP {response.StatusCode} - {error}");
     }
+
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/IAppNotificationSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/IAppNotificationSender.cs
@@ -5,11 +5,11 @@ namespace Masa.Mc.Infrastructure.AppNotification;
 
 public interface IAppNotificationSender: ITransientDependency
 {
-    Task<AppNotificationResponseBase> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default);
+    Task<AppNotificationResponse> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default);
 
-    Task<AppNotificationResponseBase> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default);
+    Task<AppNotificationResponse> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default);
 
-    Task<AppNotificationResponseBase> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default);
+    Task<AppNotificationResponse> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default);
 
-    Task<AppNotificationResponseBase> WithdrawnAsync(string msgId, CancellationToken ct = default);
+    Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default);
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Model/Response/AppNotificationResponse.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Model/Response/AppNotificationResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Masa.Mc.Infrastructure.AppNotification.Model.Response;
 
-public class AppNotificationResponseBase
+public class AppNotificationResponse
 {
     public bool Success { get; }
 
@@ -11,10 +11,13 @@ public class AppNotificationResponseBase
 
     public string MsgId { get; set; } = string.Empty;
 
-    public AppNotificationResponseBase(bool success, string message, string msgId = "")
+    public List<string> ErrorTokens { get; set; }
+
+    public AppNotificationResponse(bool success, string message, string msgId = "", List<string> errorTokens = null)
     {
         Success = success;
         Message = message;
         MsgId = msgId;
+        ErrorTokens = errorTokens ?? new();
     }
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiPushSender.cs
@@ -87,7 +87,7 @@ public class XiaomiPushSender : IAppNotificationSender
         {
             Content = new FormUrlEncodedContent(payload)
         };
-        request.Headers.Authorization = new AuthenticationHeaderValue("key", options.AppSecret);
+        request.Headers.TryAddWithoutValidation("Authorization", $"key={options.AppSecret}");
 
         try
         {

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/_Imports.cs
@@ -32,3 +32,4 @@ global using System.Net.Http.Headers;
 global using System.Net.Http.Json;
 global using System.Text;
 global using System.Text.Json;
+global using System.Text.Json.Serialization;

--- a/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/ExecuteMessageTaskEventHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/ExecuteMessageTaskEventHandler.cs
@@ -37,8 +37,7 @@ public class ExecuteMessageTaskEventHandler
             var messageTask = await _messageTaskRepository.FindAsync(x => x.Id == eto.MessageTaskId, false);
             if (messageTask == null) return;
 
-            Guid userId = Guid.Empty;
-            await _messageTaskJobService.DisableJobAsync(messageTask.SchedulerJobId, userId);
+            await _messageTaskJobService.DisableJobAsync(messageTask.SchedulerJobId, Guid.Empty);
             return;
         }
         history.SetTaskId(eto.TaskId);

--- a/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/SendAppMessageEventHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/SendAppMessageEventHandler.cs
@@ -9,204 +9,234 @@ public class SendAppMessageEventHandler
     private readonly IChannelRepository _channelRepository;
     private readonly IMessageRecordRepository _messageRecordRepository;
     private readonly IMessageTaskHistoryRepository _messageTaskHistoryRepository;
-    private readonly MessageTemplateDomainService _messageTemplateDomainService;
-    private readonly ILogger<SendEmailMessageEventHandler> _logger;
-    private readonly IMessageTemplateRepository _messageTemplateRepository;
+    private readonly ILogger<SendAppMessageEventHandler> _logger;
     private readonly IWebsiteMessageRepository _websiteMessageRepository;
-    private readonly II18n<DefaultResource> _i18n;
+    private readonly IAppVendorConfigRepository _appVendorConfigRepository;
 
     public SendAppMessageEventHandler(
         AppNotificationSenderFactory appNotificationSenderFactory,
         IChannelRepository channelRepository,
         IMessageRecordRepository messageRecordRepository,
         IMessageTaskHistoryRepository messageTaskHistoryRepository,
-        MessageTemplateDomainService messageTemplateDomainService,
-        ILogger<SendEmailMessageEventHandler> logger,
-        IMessageTemplateRepository messageTemplateRepository,
+        ILogger<SendAppMessageEventHandler> logger,
         IWebsiteMessageRepository websiteMessageRepository,
-        II18n<DefaultResource> i18n)
+        IAppVendorConfigRepository appVendorConfigRepository)
     {
         _appNotificationSenderFactory = appNotificationSenderFactory;
         _channelRepository = channelRepository;
         _messageRecordRepository = messageRecordRepository;
         _messageTaskHistoryRepository = messageTaskHistoryRepository;
-        _messageTemplateDomainService = messageTemplateDomainService;
         _logger = logger;
-        _messageTemplateRepository = messageTemplateRepository;
         _websiteMessageRepository = websiteMessageRepository;
-        _i18n = i18n;
+        _appVendorConfigRepository = appVendorConfigRepository;
     }
 
     [EventHandler]
     public async Task HandleEventAsync(SendAppMessageEvent eto)
     {
         var channel = await _channelRepository.FindAsync(x => x.Id == eto.ChannelId);
-        var provider = (Providers)channel.ExtraProperties.GetProperty<int>(nameof(AppChannelOptions.Provider));
-        var options = _appNotificationSenderFactory.GetOptions(provider, channel.ExtraProperties);
-        var asyncLocal = _appNotificationSenderFactory.GetProviderAsyncLocal(provider);
+        var taskHistory = eto.MessageTaskHistory;
+        var transmissionContent = GetTransmissionContent(channel.Type, eto.MessageData.MessageContent);
+
+        var channelProvider = channel.ExtraProperties.GetProperty<int>(nameof(AppChannelOptions.Provider));
+
+        if (channelProvider == (int)AppChannelProviders.Mc)
+        {
+            await SendMcAppMessageAsync(eto, transmissionContent);
+        }
+        else
+        {
+            await SendThirdPartyAppMessageAsync(eto, channelProvider, channel.ExtraProperties, transmissionContent, taskHistory);
+        }
+
+        await _messageTaskHistoryRepository.UpdateAsync(taskHistory);
+    }
+
+    private ExtraPropertyDictionary GetTransmissionContent(ChannelType channelType, MessageContent messageContent)
+    {
+        var appChannel = channelType as ChannelType.AppsChannel;
+        return appChannel?.GetMessageTransmissionContent(messageContent) ?? new ExtraPropertyDictionary();
+    }
+
+    private async Task SendThirdPartyAppMessageAsync(SendAppMessageEvent eto, int channelProvider, ConcurrentDictionary<string, object> channelProperties, ExtraPropertyDictionary transmissionContent, MessageTaskHistory taskHistory)
+    {
+        var appSenderProvider = (Providers)channelProvider;
+        var options = _appNotificationSenderFactory.GetOptions(appSenderProvider, channelProperties);
+        var asyncLocal = _appNotificationSenderFactory.GetProviderAsyncLocal(appSenderProvider);
 
         using (asyncLocal.Change(options))
         {
-            var taskHistory = eto.MessageTaskHistory;
-            var appChannel = channel.Type as ChannelType.AppsChannel;
-            var transmissionContent = appChannel.GetMessageTransmissionContent(eto.MessageData.MessageContent);
-            var sender = _appNotificationSenderFactory.GetAppNotificationSender(provider);
-
-            if (taskHistory.MessageTask.ReceiverType == ReceiverTypes.Broadcast)
-            {
-                await HandleBroadcastAsync(taskHistory, sender, eto.MessageData, transmissionContent);
-            }
-            else if (!taskHistory.MessageTask.Receivers.Any(x => x.Type == MessageTaskReceiverTypes.User))
-            {
-                await HandleBatchAsync(eto.ChannelId, taskHistory, sender, eto.MessageData, transmissionContent);
-            }
-            else
-            {
-                await HandleSingleAsync(eto.ChannelId, taskHistory, sender, eto.MessageData, transmissionContent);
-            }
+            var sender = _appNotificationSenderFactory.GetAppNotificationSender(appSenderProvider);
+            var sendStatus = await SendMessageBasedOnReceiverTypeAsync(sender, eto, transmissionContent, taskHistory);
+            taskHistory.SetResult(sendStatus);
         }
     }
 
-    private async Task HandleBroadcastAsync(MessageTaskHistory taskHistory, IAppNotificationSender sender, MessageData data, ExtraPropertyDictionary transmissionContent)
+    private async Task<MessageSendStatuses> SendMessageBasedOnReceiverTypeAsync(IAppNotificationSender sender, SendAppMessageEvent eto, ExtraPropertyDictionary transmissionContent, MessageTaskHistory taskHistory)
     {
-        var response = await sender.BroadcastSendAsync(new AppMessage(
+        var receiverType = taskHistory.MessageTask.ReceiverType;
+        var isUniformContent = taskHistory.MessageTask.IsUniformContent;
+        var isWebsiteMessage = taskHistory.MessageTask.IsAppInWebsiteMessage;
+
+        return receiverType switch
+        {
+            ReceiverTypes.Broadcast => await HandleBroadcastAsync(sender, eto.MessageData, transmissionContent),
+            _ when isUniformContent => await HandleBatchAsync(sender, eto.ChannelId, taskHistory, taskHistory.ReceiverUsers, eto.MessageData, transmissionContent, isWebsiteMessage),
+            _ => await HandleSingleAsync(sender, eto.ChannelId, taskHistory, taskHistory.ReceiverUsers, eto.MessageData, transmissionContent)
+        };
+    }
+
+    private async Task SendMcAppMessageAsync(SendAppMessageEvent eto, ExtraPropertyDictionary transmissionContent)
+    {
+        var messageData = eto.MessageData;
+        var messageTaskHistory = eto.MessageTaskHistory;
+        var groupByPlatform = GroupUsersByPlatform(messageTaskHistory.ReceiverUsers);
+
+        var sendStatuses = new List<MessageSendStatuses>();
+
+        foreach (var platformGroup in groupByPlatform)
+        {
+            var result = await SendToPlatformAsync(platformGroup.Key, platformGroup.Value, eto, transmissionContent);
+            sendStatuses.Add(result);
+        }
+
+        var status = DetermineOverallStatus(sendStatuses);
+        eto.MessageTaskHistory.SetResult(status);
+    }
+
+    private Dictionary<Providers, IEnumerable<MessageReceiverUser>> GroupUsersByPlatform(IEnumerable<MessageReceiverUser> users)
+    {
+        return users.GroupBy(x => Enum.Parse<Providers>(x.Platform)).ToDictionary(g => g.Key, g => g.AsEnumerable());
+    }
+
+    private async Task<MessageSendStatuses> SendToPlatformAsync(Providers platform, IEnumerable<MessageReceiverUser> users, SendAppMessageEvent eto, ExtraPropertyDictionary transmissionContent)
+    {
+        var vendorConfig = await _appVendorConfigRepository.FindAsync(x => x.ChannelId == eto.ChannelId && x.Vendor == (AppVendor)platform);
+
+        if (vendorConfig == null)
+        {
+            _logger.LogWarning("No vendor config found for platform: {Platform}", platform);
+            return MessageSendStatuses.Fail;
+        }
+
+        var options = _appNotificationSenderFactory.GetOptions(platform, vendorConfig.Options);
+        var asyncLocal = _appNotificationSenderFactory.GetProviderAsyncLocal(platform);
+
+        using (asyncLocal.Change(options))
+        {
+            var sender = _appNotificationSenderFactory.GetAppNotificationSender(platform);
+            return await SendMessageBasedOnReceiverTypeAsync(sender, eto, transmissionContent, eto.MessageTaskHistory);
+        }
+    }
+
+    private MessageSendStatuses DetermineOverallStatus(List<MessageSendStatuses> sendStatuses)
+    {
+        return !sendStatuses.Any(x => x != MessageSendStatuses.Success)
+            ? MessageSendStatuses.Success
+            : sendStatuses.Any(x => x == MessageSendStatuses.Success)
+                ? MessageSendStatuses.PartialFailure
+                : MessageSendStatuses.Fail;
+    }
+
+    private async Task<MessageSendStatuses> HandleBroadcastAsync(IAppNotificationSender sender, MessageData data, ExtraPropertyDictionary transmissionContent)
+    {
+        try
+        {
+            var message = CreateAppMessage(data, transmissionContent);
+            var response = await sender.BroadcastSendAsync(message);
+            return response.Success ? MessageSendStatuses.Success : MessageSendStatuses.Fail;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send broadcast message.");
+            return MessageSendStatuses.Fail;
+        }
+    }
+
+    private AppMessage CreateAppMessage(MessageData data, ExtraPropertyDictionary transmissionContent)
+    {
+        return new AppMessage(
             data.MessageContent.Title,
             data.MessageContent.Content,
             data.GetDataValue<string>(BusinessConsts.INTENT_URL),
             transmissionContent,
             data.GetDataValue<bool>(BusinessConsts.IS_APNS_PRODUCTION)
-        ));
-
-        taskHistory.SetResult(response.Success ? MessageTaskHistoryStatuses.Success : MessageTaskHistoryStatuses.Fail);
-        await _messageTaskHistoryRepository.UpdateAsync(taskHistory);
+        );
     }
 
-    private async Task HandleBatchAsync(Guid channelId, MessageTaskHistory taskHistory, IAppNotificationSender sender, MessageData data, ExtraPropertyDictionary transmissionContent)
+    private async Task<MessageSendStatuses> HandleBatchAsync(IAppNotificationSender sender, Guid channelId, MessageTaskHistory taskHistory, List<MessageReceiverUser> receiverUsers, MessageData data, ExtraPropertyDictionary transmissionContent, bool isWebsiteMessage)
     {
-        var userIdentities = taskHistory.ReceiverUsers.Select(x => x.ChannelUserIdentity).Distinct().ToArray();
         const int batchSize = 1000;
-        int totalBatches = (int)Math.Ceiling((double)userIdentities.Length / batchSize);
-        int successCount = 0;
+        var userIdentities = receiverUsers.Select(x => x.ChannelUserIdentity).Distinct().ToArray();
+        var totalBatches = (int)Math.Ceiling((double)userIdentities.Length / batchSize);
+        var successCount = 0;
+        var records = receiverUsers.Select(user => CreateMessageRecord(user, channelId, taskHistory, data)).ToList();
 
         for (int i = 0; i < totalBatches; i++)
         {
             var batch = userIdentities.Skip(i * batchSize).Take(batchSize).ToArray();
-            var response = await sender.BatchSendAsync(new BatchAppMessage(
-                batch,
-                data.MessageContent.Title,
-                data.MessageContent.Content,
-                data.GetDataValue<string>(BusinessConsts.INTENT_URL),
-                transmissionContent,
-                data.GetDataValue<bool>(BusinessConsts.IS_APNS_PRODUCTION)
-            ));
+            try
+            {
+                var message = CreateBatchAppMessage(batch, data, transmissionContent);
+                var response = await sender.BatchSendAsync(message);
 
-            if (response.Success)
-                successCount++;
+                successCount += UpdateRecordsWithResponse(records, batch, response);
+                if (isWebsiteMessage)
+                {
+                    await AddWebsiteMessages(records, batch, channelId, data);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred during BatchSendAsync in HandleBatchAsync");
+                foreach (var item in batch)
+                {
+                    var record = records.FirstOrDefault(x => x.ChannelUserIdentity == item);
+                    if (record is not null)
+                    {
+                        record.SetResult(false, ex.Message);
+                    }
+                }
+            }
         }
 
-        if (taskHistory.MessageTask.IsAppInWebsiteMessage)
-        {
-            var websiteMessages = taskHistory.ReceiverUsers.Select(u =>
-                new WebsiteMessage(
-                    taskHistory.Id,
-                    channelId,
-                    u.UserId,
-                    data.MessageContent.Title,
-                    data.MessageContent.Content,
-                    data.MessageContent.GetJumpUrl(),
-                    DateTimeOffset.UtcNow,
-                    data.MessageContent.ExtraProperties
-                )).ToList();
-
-            await _websiteMessageRepository.AddRangeAsync(websiteMessages);
-        }
-
-        var status = successCount == totalBatches
-            ? MessageTaskHistoryStatuses.Success
-            : successCount > 0
-                ? MessageTaskHistoryStatuses.PartialFailure
-                : MessageTaskHistoryStatuses.Fail;
-
-        taskHistory.SetResult(status);
-        await _messageTaskHistoryRepository.UpdateAsync(taskHistory);
+        await _messageRecordRepository.AddRangeAsync(records);
+        return DetermineBatchStatus(successCount, receiverUsers.Count);
     }
 
-    private async Task HandleSingleAsync(Guid channelId, MessageTaskHistory taskHistory, IAppNotificationSender sender, MessageData data, ExtraPropertyDictionary transmissionContent)
+    private BatchAppMessage CreateBatchAppMessage(string[] batch, MessageData data, ExtraPropertyDictionary transmissionContent)
     {
-        int successCount = 0;
-        int totalCount = taskHistory.ReceiverUsers.Count;
+        return new BatchAppMessage(
+            batch,
+            data.MessageContent.Title,
+            data.MessageContent.Content,
+            data.GetDataValue<string>(BusinessConsts.INTENT_URL),
+            transmissionContent,
+            data.GetDataValue<bool>(BusinessConsts.IS_APNS_PRODUCTION)
+        );
+    }
 
-        var messageTemplate = await _messageTemplateRepository.FindAsync(x => x.Id == taskHistory.MessageTask.EntityId, false);
+    private async Task<MessageSendStatuses> HandleSingleAsync(IAppNotificationSender sender, Guid channelId, MessageTaskHistory taskHistory, List<MessageReceiverUser> receiverUsers, MessageData data, ExtraPropertyDictionary transmissionContent)
+    {
+        var successCount = 0;
         var records = new List<MessageRecord>();
         var websiteMessages = new List<WebsiteMessage>();
 
-        foreach (var user in taskHistory.ReceiverUsers)
+        foreach (var user in receiverUsers)
         {
-            var record = new MessageRecord(
-                user.UserId,
-                user.ChannelUserIdentity,
-                channelId,
-                taskHistory.MessageTaskId,
-                taskHistory.Id,
-                user.Variables,
-                data.MessageContent.Title,
-                taskHistory.SendTime,
-                taskHistory.MessageTask.SystemId
-            );
-
-            record.SetMessageEntity(taskHistory.MessageTask.EntityType, taskHistory.MessageTask.EntityId);
-            data.RenderContent(user.Variables);
-
-            if (data.MessageType == MessageEntityTypes.Template &&
-                !await _messageTemplateDomainService.CheckSendUpperLimitAsync(messageTemplate, record.ChannelUserIdentity))
-            {
-                record.SetResult(false, _i18n.T("DailySendingLimit"));
-                records.Add(record);
-                continue;
-            }
-
+            var record = CreateMessageRecord(user, channelId, taskHistory, data);
             try
             {
-                if (taskHistory.MessageTask.IsAppInWebsiteMessage || messageTemplate?.IsWebsiteMessage == true)
+                if (taskHistory.MessageTask.IsAppInWebsiteMessage)
                 {
-                    websiteMessages.Add(new WebsiteMessage(
-                        record.MessageTaskHistoryId,
-                        record.ChannelId,
-                        user.UserId,
-                        data.MessageContent.Title,
-                        data.MessageContent.Content,
-                        data.MessageContent.GetJumpUrl(),
-                        DateTimeOffset.UtcNow,
-                        data.MessageContent.ExtraProperties
-                    ));
+                    websiteMessages.Add(CreateWebsiteMessage(record, user, data));
                 }
 
-                if (string.IsNullOrEmpty(user.ChannelUserIdentity))
-                {
-                    record.SetResult(false, _i18n.T("ClientIdNotBound"));
-                }
-                else
-                {
-                    var response = await sender.SendAsync(new SingleAppMessage(
-                        user.ChannelUserIdentity,
-                        data.MessageContent.Title,
-                        data.MessageContent.Content,
-                        data.GetDataValue<string>(BusinessConsts.INTENT_URL),
-                        transmissionContent,
-                        data.GetDataValue<bool>(BusinessConsts.IS_APNS_PRODUCTION)
-                    ));
+                var message = CreateSingleAppMessage(user.ChannelUserIdentity, data, transmissionContent);
+                var response = await sender.SendAsync(message);
 
-                    if (response.Success)
-                    {
-                        record.SetResult(true, string.Empty);
-                        record.SetDataValue(BusinessConsts.APP_PUSH_MSG_ID, response.MsgId);
-                        successCount++;
-                    }
-                    else
-                    {
-                        record.SetResult(false, response.Message);
-                    }
-                }
+                UpdateRecordWithResponse(record, response);
+                if (response.Success) successCount++;
             }
             catch (Exception ex)
             {
@@ -220,13 +250,111 @@ public class SendAppMessageEventHandler
         await _messageRecordRepository.AddRangeAsync(records);
         await _websiteMessageRepository.AddRangeAsync(websiteMessages);
 
-        var finalStatus = successCount == totalCount
-            ? MessageTaskHistoryStatuses.Success
-            : successCount > 0
-                ? MessageTaskHistoryStatuses.PartialFailure
-                : MessageTaskHistoryStatuses.Fail;
+        return DetermineBatchStatus(successCount, receiverUsers.Count);
+    }
 
-        taskHistory.SetResult(finalStatus);
-        await _messageTaskHistoryRepository.UpdateAsync(taskHistory);
+    private SingleAppMessage CreateSingleAppMessage(string token, MessageData data, ExtraPropertyDictionary transmissionContent)
+    {
+        return new SingleAppMessage(
+            token,
+            data.MessageContent.Title,
+            data.MessageContent.Content,
+            data.GetDataValue<string>(BusinessConsts.INTENT_URL),
+            transmissionContent,
+            data.GetDataValue<bool>(BusinessConsts.IS_APNS_PRODUCTION)
+        );
+    }
+
+    private MessageRecord CreateMessageRecord(MessageReceiverUser user, Guid channelId, MessageTaskHistory taskHistory, MessageData data)
+    {
+        var record = new MessageRecord(
+            user.UserId,
+            user.ChannelUserIdentity,
+            channelId,
+            taskHistory.MessageTaskId,
+            taskHistory.Id,
+            user.Variables,
+            data.MessageContent.Title,
+            taskHistory.SendTime,
+            taskHistory.MessageTask.SystemId
+        );
+        record.SetMessageEntity(taskHistory.MessageTask.EntityType, taskHistory.MessageTask.EntityId);
+        data.RenderContent(user.Variables);
+        return record;
+    }
+
+    private WebsiteMessage CreateWebsiteMessage(MessageRecord record, MessageReceiverUser user, MessageData data)
+    {
+        return new WebsiteMessage(
+            record.MessageTaskHistoryId,
+            record.ChannelId,
+            user.UserId,
+            data.MessageContent.Title,
+            data.MessageContent.Content,
+            data.MessageContent.GetJumpUrl(),
+            DateTimeOffset.UtcNow,
+            data.MessageContent.ExtraProperties
+        );
+    }
+
+    private int UpdateRecordsWithResponse(List<MessageRecord> records, string[] batch, AppNotificationResponse response)
+    {
+        var successCount = 0;
+        foreach (var item in batch)
+        {
+            var record = records.FirstOrDefault(x => x.ChannelUserIdentity == item);
+            if (record is not null)
+            {
+                if (!response.Success || response.ErrorTokens.Contains(item))
+                {
+                    record.SetResult(false, response.Message);
+                }
+                else
+                {
+                    record.SetResult(true, string.Empty);
+                    record.SetDataValue(BusinessConsts.APP_PUSH_MSG_ID, response.MsgId);
+                    successCount++;
+                }
+            }
+        }
+        return successCount;
+    }
+
+    private async Task AddWebsiteMessages(List<MessageRecord> records, string[] batch, Guid channelId, MessageData data)
+    {
+        var websiteMessages = records.Where(x => batch.Contains(x.ChannelUserIdentity)).Select(record =>
+            new WebsiteMessage(
+                record.MessageTaskHistoryId,
+                channelId,
+                record.UserId,
+                data.MessageContent.Title,
+                data.MessageContent.Content,
+                data.MessageContent.GetJumpUrl(),
+                DateTimeOffset.UtcNow,
+                data.MessageContent.ExtraProperties
+            )).ToList();
+        await _websiteMessageRepository.AddRangeAsync(websiteMessages);
+    }
+
+    private void UpdateRecordWithResponse(MessageRecord record, AppNotificationResponse response)
+    {
+        if (response.Success)
+        {
+            record.SetResult(true, string.Empty);
+            record.SetDataValue(BusinessConsts.APP_PUSH_MSG_ID, response.MsgId);
+        }
+        else
+        {
+            record.SetResult(false, response.Message);
+        }
+    }
+
+    private MessageSendStatuses DetermineBatchStatus(int successCount, int totalCount)
+    {
+        return successCount == totalCount
+            ? MessageSendStatuses.Success
+            : successCount > 0
+                ? MessageSendStatuses.PartialFailure
+                : MessageSendStatuses.Fail;
     }
 }

--- a/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/SendAppMessageEventHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/MessageTasks/EventHandler/SendAppMessageEventHandler.cs
@@ -94,7 +94,7 @@ public class SendAppMessageEventHandler
         return receiverType switch
         {
             ReceiverTypes.Broadcast => await HandleBroadcastAsync(sender, eto.MessageData, transmissionContent),
-            _ when isUniformContent => await HandleBatchAsync(sender, eto.ChannelId, taskHistory, taskHistory.ReceiverUsers, eto.MessageData, transmissionContent, isWebsiteMessage),
+            _ when isUniformContent && taskHistory.ReceiverUsers.Count > 1 => await HandleBatchAsync(sender, eto.ChannelId, taskHistory, taskHistory.ReceiverUsers, eto.MessageData, transmissionContent, isWebsiteMessage),
             _ => await HandleSingleAsync(sender, eto.ChannelId, taskHistory, taskHistory.ReceiverUsers, eto.MessageData, transmissionContent)
         };
     }

--- a/src/Services/Masa.Mc.Service/_Imports.cs
+++ b/src/Services/Masa.Mc.Service/_Imports.cs
@@ -187,3 +187,4 @@ global using Masa.Mc.Domain.Consts;
 global using Masa.Mc.Data;
 global using Masa.Mc.Infrastructure.EntityFrameworkCore.ValueConverters;
 global using Masa.Mc.Infrastructure.ObjectExtending;
+global using Masa.Mc.Infrastructure.AppNotification.Model.Response;


### PR DESCRIPTION
Refactor the code to unify the notification response model, remove 'AppNotificationResponseBase', and use 'AppNotificationResponse' instead.
Optimize the push service logic, support some successful push scenarios and return the failed device token list.
Add the 'Platform' attribute and update the database model to support user platform information.
Reconstruct multiple classes to improve code readability and maintainability, simplify method logic, and delete redundant code. Add a new enumeration 'MessageSendStatus' to indicate the message sending status and enhance the error handling capability.