### PR TITLE
新增通知订阅与取消订阅功能支持

### DIFF
--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250617032649_AppDeviceTokenIndex.Designer.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250617032649_AppDeviceTokenIndex.Designer.cs
@@ -3,67 +3,69 @@ using System;
 using Masa.Mc.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Masa.Mc.Service.Admin.Migrations
+namespace Masa.Mc.EntityFrameworkCore.PostgreSql.Migrations
 {
     [DbContext(typeof(McDbContext))]
-    partial class McDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250617032649_AppDeviceTokenIndex")]
+    partial class AppDeviceTokenIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "6.0.7")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Masa.BuildingBlocks.Dispatcher.IntegrationEvents.Logs.IntegrationEventLog", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("EventTypeName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ExpandContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RowVersion")
                         .IsConcurrencyToken()
                         .IsRequired()
                         .HasMaxLength(36)
-                        .HasColumnType("nvarchar(36)")
+                        .HasColumnType("character varying(36)")
                         .HasColumnName("RowVersion");
 
                     b.Property<int>("State")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("TimesSent")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -80,43 +82,43 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("DeviceToken")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("Platform")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("RegisteredTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -129,32 +131,32 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Options")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Vendor")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -166,46 +168,46 @@ namespace Masa.Mc.Service.Admin.Migrations
             modelBuilder.Entity("Masa.Mc.Domain.Channels.Aggregates.AppChannel", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)")
+                        .HasColumnType("character varying(64)")
                         .HasColumnName("Code");
 
                     b.Property<string>("Color")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("Color");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("DisplayName");
 
                     b.Property<string>("Scheme")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("Scheme");
 
                     b.Property<string>("SchemeField")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("SchemeField");
 
                     b.Property<int>("Type")
                         .ValueGeneratedOnUpdateSometimes()
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("Type");
 
                     b.HasKey("Id");
@@ -217,73 +219,73 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)")
+                        .HasColumnType("character varying(64)")
                         .HasColumnName("Code");
 
                     b.Property<string>("Color")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("Color");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("DisplayName");
 
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsStatic")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Scheme")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("Scheme");
 
                     b.Property<string>("SchemeField")
                         .IsRequired()
                         .ValueGeneratedOnUpdateSometimes()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)")
+                        .HasColumnType("character varying(128)")
                         .HasColumnName("SchemeField");
 
                     b.Property<int>("Type")
                         .ValueGeneratedOnUpdateSometimes()
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("Type");
 
                     b.HasKey("Id");
@@ -299,25 +301,25 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -328,76 +330,76 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ChannelUserIdentity")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTimeOffset?>("ExpectSendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("FailureReason")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid>("MessageEntityId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("MessageEntityType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("MessageTaskHistoryId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("MessageTaskId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset?>("SendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool?>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SystemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Variables")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -414,27 +416,27 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ChannelUserIdentity")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<Guid?>("MessageTaskHistoryId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Platform")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Variables")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -447,92 +449,92 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int?>("ChannelType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<Guid>("EntityId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("EntityType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset?>("ExpectSendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDraft")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("ReceiverType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Receivers")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<Guid>("SchedulerJobId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("SelectReceiverType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SendRules")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("SendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Sign")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Source")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Status")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SystemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Variables")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -547,48 +549,48 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset?>("CompletionTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsTest")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid>("MessageTaskId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("SchedulerTaskId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset?>("SendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Status")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("TaskHistoryNo")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTimeOffset?>("WithdrawTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -601,59 +603,59 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuditReason")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("AuditStatus")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset?>("AuditTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Example")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("InvalidTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsStatic")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Options")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<long>("PerDayLimit")
                         .HasColumnType("bigint");
@@ -661,18 +663,18 @@ namespace Masa.Mc.Service.Admin.Migrations
                     b.Property<string>("Sign")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Status")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("TemplateId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("TemplateType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -687,29 +689,29 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("DisplayText")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("MappingCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<Guid>("MessageTemplateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -724,46 +726,46 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuditReason")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("AuditStatus")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("TemplateCode")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("TemplateContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TemplateName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("TemplateType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -776,31 +778,31 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -811,61 +813,61 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("ChannelId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsRead")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsWithdrawn")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("LinkUrl")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<Guid>("MessageTaskHistoryId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset?>("ReadTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("SendTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -880,28 +882,28 @@ namespace Masa.Mc.Service.Admin.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Creator")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("ModificationTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("Modifier")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset>("UpdateTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -924,38 +926,38 @@ namespace Masa.Mc.Service.Admin.Migrations
                     b.OwnsOne("Masa.Mc.Domain.MessageInfos.Aggregates.MessageContent", "MessageContent", b1 =>
                         {
                             b1.Property<Guid>("MessageInfoId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("Content");
 
                             b1.Property<string>("ExtraProperties")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("ExtraProperties");
 
                             b1.Property<bool>("IsJump")
                                 .HasMaxLength(128)
-                                .HasColumnType("bit")
+                                .HasColumnType("boolean")
                                 .HasColumnName("IsJump");
 
                             b1.Property<string>("JumpUrl")
                                 .IsRequired()
                                 .HasMaxLength(256)
-                                .HasColumnType("nvarchar(256)")
+                                .HasColumnType("character varying(256)")
                                 .HasColumnName("JumpUrl");
 
                             b1.Property<string>("Markdown")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("Markdown");
 
                             b1.Property<string>("Title")
                                 .IsRequired()
                                 .HasMaxLength(128)
-                                .HasColumnType("nvarchar(128)")
+                                .HasColumnType("character varying(128)")
                                 .HasColumnName("Title");
 
                             b1.HasKey("MessageInfoId");
@@ -1013,38 +1015,38 @@ namespace Masa.Mc.Service.Admin.Migrations
                     b.OwnsOne("Masa.Mc.Domain.MessageInfos.Aggregates.MessageContent", "MessageContent", b1 =>
                         {
                             b1.Property<Guid>("MessageTemplateId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("Content");
 
                             b1.Property<string>("ExtraProperties")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("ExtraProperties");
 
                             b1.Property<bool>("IsJump")
                                 .HasMaxLength(128)
-                                .HasColumnType("bit")
+                                .HasColumnType("boolean")
                                 .HasColumnName("IsJump");
 
                             b1.Property<string>("JumpUrl")
                                 .IsRequired()
                                 .HasMaxLength(256)
-                                .HasColumnType("nvarchar(256)")
+                                .HasColumnType("character varying(256)")
                                 .HasColumnName("JumpUrl");
 
                             b1.Property<string>("Markdown")
                                 .IsRequired()
-                                .HasColumnType("nvarchar(max)")
+                                .HasColumnType("text")
                                 .HasColumnName("Markdown");
 
                             b1.Property<string>("Title")
                                 .IsRequired()
                                 .HasMaxLength(128)
-                                .HasColumnType("nvarchar(128)")
+                                .HasColumnType("character varying(128)")
                                 .HasColumnName("Title");
 
                             b1.HasKey("MessageTemplateId");
@@ -1073,27 +1075,27 @@ namespace Masa.Mc.Service.Admin.Migrations
                     b.OwnsMany("Masa.Mc.Domain.ReceiverGroups.Aggregates.ReceiverGroupItem", "Items", b1 =>
                         {
                             b1.Property<Guid>("GroupId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<Guid>("Id")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<string>("Avatar")
                                 .IsRequired()
                                 .HasMaxLength(128)
-                                .HasColumnType("nvarchar(128)");
+                                .HasColumnType("character varying(128)");
 
                             b1.Property<string>("DisplayName")
                                 .IsRequired()
                                 .HasMaxLength(128)
-                                .HasColumnType("nvarchar(128)");
+                                .HasColumnType("character varying(128)");
 
                             b1.Property<Guid>("SubjectId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("Type")
-                                .HasColumnType("int");
+                                .HasColumnType("integer");
 
                             b1.HasKey("GroupId", "Id");
 
@@ -1118,26 +1120,26 @@ namespace Masa.Mc.Service.Admin.Migrations
                         {
                             b1.Property<Guid>("Id")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<Guid>("ChannelId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<DateTime>("CreationTime")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType("datetime2");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Tag")
                                 .IsRequired()
                                 .HasMaxLength(128)
-                                .HasColumnType("nvarchar(128)")
+                                .HasColumnType("character varying(128)")
                                 .HasColumnName("Tag");
 
                             b1.Property<Guid>("UserId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<Guid>("WebsiteMessageId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.HasKey("Id");
 

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250617032649_AppDeviceTokenIndex.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/20250617032649_AppDeviceTokenIndex.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Masa.Mc.EntityFrameworkCore.PostgreSql.Migrations
+{
+    public partial class AppDeviceTokenIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId",
+                table: "AppDeviceTokens");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId_Platform",
+                table: "AppDeviceTokens",
+                columns: new[] { "ChannelId", "UserId", "Platform" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId_Platform",
+                table: "AppDeviceTokens");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId",
+                table: "AppDeviceTokens",
+                columns: new[] { "ChannelId", "UserId" });
+        }
+    }
+}

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/McDbContextModelSnapshot.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.PostgreSql/Migrations/McDbContextModelSnapshot.cs
@@ -120,7 +120,7 @@ namespace Masa.Mc.EntityFrameworkCore.PostgreSql.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("ChannelId", "UserId");
+                    b.HasIndex("ChannelId", "UserId", "Platform");
 
                     b.ToTable("AppDeviceTokens", (string)null);
                 });

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.SqlServer/Migrations/20250617032711_AppDeviceTokenIndex.Designer.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.SqlServer/Migrations/20250617032711_AppDeviceTokenIndex.Designer.cs
@@ -4,6 +4,7 @@ using Masa.Mc.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Masa.Mc.Service.Admin.Migrations
 {
     [DbContext(typeof(McDbContext))]
-    partial class McDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250617032711_AppDeviceTokenIndex")]
+    partial class AppDeviceTokenIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore.SqlServer/Migrations/20250617032711_AppDeviceTokenIndex.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore.SqlServer/Migrations/20250617032711_AppDeviceTokenIndex.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Masa.Mc.Service.Admin.Migrations
+{
+    public partial class AppDeviceTokenIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId",
+                table: "AppDeviceTokens");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Platform",
+                table: "MessageReceiverUsers",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId_Platform",
+                table: "AppDeviceTokens",
+                columns: new[] { "ChannelId", "UserId", "Platform" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId_Platform",
+                table: "AppDeviceTokens");
+
+            migrationBuilder.DropColumn(
+                name: "Platform",
+                table: "MessageReceiverUsers");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppDeviceTokens_ChannelId_UserId",
+                table: "AppDeviceTokens",
+                columns: new[] { "ChannelId", "UserId" });
+        }
+    }
+}

--- a/src/Infrastructure/Masa.Mc.EntityFrameworkCore/McDbContextModelBuilderExtensions.cs
+++ b/src/Infrastructure/Masa.Mc.EntityFrameworkCore/McDbContextModelBuilderExtensions.cs
@@ -163,7 +163,7 @@ public static class McDbContextModelBuilderExtensions
             b.ToTable(MCConsts.DbTablePrefix + "AppDeviceTokens", MCConsts.DbSchema);
             b.Property(x => x.DeviceToken).HasMaxLength(128);
             b.Property(x => x.ExtraProperties).HasConversion(new ExtraPropertiesValueConverter()).Metadata.SetValueComparer(new ExtraPropertyDictionaryValueComparer());
-            b.HasIndex(x => new { x.ChannelId, x.UserId });
+            b.HasIndex(x => new { x.ChannelId, x.UserId, x.Platform });
         });
 
         builder.Entity<AppVendorConfig>(b =>

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Getui/GetuiSender.cs
@@ -7,6 +7,8 @@ public class GetuiSender : IAppNotificationSender
 {
     private readonly IOptionsResolver<IGetuiOptions> _optionsResolver;
 
+    public bool SupportsBroadcast => true;
+
     public GetuiSender(IOptionsResolver<IGetuiOptions> optionsResolver)
     {
         _optionsResolver = optionsResolver;
@@ -97,4 +99,10 @@ public class GetuiSender : IAppNotificationSender
 
     public Task<AppNotificationResponse> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default)
         => Task.FromResult(new AppNotificationResponse(false, "does not support message batch send"));
+
+    public Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default) 
+        => Task.FromResult(new AppNotificationResponse(false, "does not support subscribe"));
+
+    public Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponse(false, "does not support unsubscribe"));
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Honor/HonorPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Honor/HonorPushSender.cs
@@ -11,6 +11,8 @@ public class HonorPushSender : IAppNotificationSender
     private readonly HonorAuthService _authService;
     private readonly IOptionsResolver<IHonorPushOptions> _optionsResolver;
 
+    public bool SupportsBroadcast => false;
+
     public HonorPushSender(HttpClient httpClient, HonorAuthService authService, IOptionsResolver<IHonorPushOptions> optionsResolver)
     {
         _httpClient = httpClient;
@@ -36,6 +38,12 @@ public class HonorPushSender : IAppNotificationSender
 
     public Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default)
         => Task.FromResult(new AppNotificationResponse(false, "Honor Push does not support message withdrawal"));
+
+    public Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponse(false, "does not support subscribe"));
+
+    public Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponse(false, "does not support unsubscribe"));
 
     private async Task<AppNotificationResponse> SendInternalAsync(AppMessage appMessage, string[] clientIds, CancellationToken ct)
     {
@@ -90,7 +98,7 @@ public class HonorPushSender : IAppNotificationSender
             ? new { type = HonorClickActionType.OpenApp }
             : url.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                 ? new { type = HonorClickActionType.OpenUrl, url }
-                : new { type = HonorClickActionType.AppDefinedIntent, action = url };
+                : new { type = HonorClickActionType.AppDefinedIntent, intent = url };
     }
 
     private async Task<AppNotificationResponse> HandleResponse(HttpResponseMessage response, CancellationToken ct)

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Huawei/HuaweiConstants.cs
@@ -14,5 +14,9 @@ namespace Masa.Mc.Infrastructure.AppNotification.Huawei
         /// HMS Push message sending base URL (replace {projectId})
         /// </summary>
         public const string PushMessageUrlFormat = "https://push-api.cloud.huawei.com/v2/{0}/messages:send";
+
+        public const string TopicSubscribeUrlFormat = "https://push-api.cloud.huawei.com/v1/{0}/topic:subscribe";
+
+        public const string TopicUnsubscribeUrlFormat = "https://push-api.cloud.huawei.com/v1/{0}/topic:unsubscribe";
     }
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/IAppNotificationSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/IAppNotificationSender.cs
@@ -3,8 +3,10 @@
 
 namespace Masa.Mc.Infrastructure.AppNotification;
 
-public interface IAppNotificationSender: ITransientDependency
+public interface IAppNotificationSender : ITransientDependency
 {
+    bool SupportsBroadcast {  get; }
+
     Task<AppNotificationResponse> SendAsync(SingleAppMessage appMessage, CancellationToken ct = default);
 
     Task<AppNotificationResponse> BatchSendAsync(BatchAppMessage appMessage, CancellationToken ct = default);
@@ -12,4 +14,8 @@ public interface IAppNotificationSender: ITransientDependency
     Task<AppNotificationResponse> BroadcastSendAsync(AppMessage appMessage, CancellationToken ct = default);
 
     Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default);
+
+    Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default);
+
+    Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default);
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/JPush/JPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/JPush/JPushSender.cs
@@ -7,6 +7,8 @@ public class JPushSender : IAppNotificationSender
 {
     private readonly IOptionsResolver<IJPushOptions> _optionsResolver;
 
+    public bool SupportsBroadcast => true;
+
     public JPushSender(IOptionsResolver<IJPushOptions> optionsResolver)
     {
         _optionsResolver = optionsResolver;
@@ -56,6 +58,12 @@ public class JPushSender : IAppNotificationSender
             ? new AppNotificationResponse(true, "ok")
             : new AppNotificationResponse(false, content);
     }
+
+    public Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponse(false, "does not support subscribe"));
+
+    public Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default)
+        => Task.FromResult(new AppNotificationResponse(false, "does not support unsubscribe"));
 
     private async Task<AppNotificationResponse> SendPushAsync(JPushClient client, PushPayload pushPayload, bool isBroadcast = false)
     {

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Model/Response/AppNotificationResponse.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Model/Response/AppNotificationResponse.cs
@@ -5,9 +5,9 @@ namespace Masa.Mc.Infrastructure.AppNotification.Model.Response;
 
 public class AppNotificationResponse
 {
-    public bool Success { get; }
+    public bool Success { get; set; }
 
-    public string Message { get; }
+    public string Message { get; set; }
 
     public string MsgId { get; set; } = string.Empty;
 

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoConstants.cs
@@ -10,4 +10,6 @@ public static class OppoConstants
     public const string UnicastBatchUrl = "https://api.push.oppomobile.com/server/v1/message/notification/unicast_batch";
     public const string SaveMessageContentUrl = "https://api.push.oppomobile.com/server/v1/message/notification/save_message_content";
     public const string BroadcastUrl = "https://api.push.oppomobile.com/server/v1/message/notification/broadcast";
+    public const string SubscribeTagsUrl = "https://api-device.push.heytapmobi.com/server/v1/device/subscribe_tags";
+    public const string UnsubscribeTagsUrl = "https://api-device.push.heytapmobi.com/server/v1/device/unsubscribe_tags";
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
@@ -140,11 +140,11 @@ public class OppoPushSender : IAppNotificationSender
             return new AppNotificationResponse(false, "registration_id is required");
 
         var payload = new Dictionary<string, object?>
-    {
-        { "auth_token", token },
-        { "registration_id", clientId },
-        { "tags", name }
-    };
+        {
+            { "auth_token", token },
+            { "registration_id", clientId },
+            { "tags", name }
+        };
 
         var request = new HttpRequestMessage(HttpMethod.Post, OppoConstants.SubscribeTagsUrl)
         {

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Oppo/OppoPushSender.cs
@@ -11,6 +11,8 @@ public class OppoPushSender : IAppNotificationSender
     private readonly OppoAuthService _authService;
     private readonly IOptionsResolver<IOppoPushOptions> _optionsResolver;
 
+    public bool SupportsBroadcast => true;
+
     public OppoPushSender(HttpClient httpClient, OppoAuthService authService, IOptionsResolver<IOppoPushOptions> optionsResolver)
     {
         _httpClient = httpClient;
@@ -87,8 +89,8 @@ public class OppoPushSender : IAppNotificationSender
             }
             else
             {
-                notification["click_action_type"] = 1;
-                notification["click_action_activity"] = appMessage.Url;
+                notification["click_action_type"] = 5;
+                notification["click_action_url"] = appMessage.Url;
             }
         }
 
@@ -129,6 +131,72 @@ public class OppoPushSender : IAppNotificationSender
 
     public Task<AppNotificationResponse> WithdrawnAsync(string msgId, CancellationToken ct = default)
         => Task.FromResult(new AppNotificationResponse(false, "OPPO Push does not support message withdrawal"));
+
+    public async Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options.AppKey, options.MasterSecret, ct);
+        if (string.IsNullOrEmpty(clientId))
+            return new AppNotificationResponse(false, "registration_id is required");
+
+        var payload = new Dictionary<string, object?>
+    {
+        { "auth_token", token },
+        { "registration_id", clientId },
+        { "tags", name }
+    };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, OppoConstants.SubscribeTagsUrl)
+        {
+            Content = JsonContent.Create(payload)
+        };
+
+        var response = await _httpClient.SendAsync(request, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+            return new AppNotificationResponse(false, $"Subscribe tag failed: {json}");
+
+        using var doc = JsonDocument.Parse(json);
+        var code = doc.RootElement.GetProperty("code").GetInt32();
+        if (code == 0)
+            return new AppNotificationResponse(true, "Subscribe tag succeeded");
+        else
+            return new AppNotificationResponse(false, $"Subscribe tag failed: {doc.RootElement.GetProperty("message").GetString()}");
+    }
+
+    public async Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default)
+    {
+        var options = await _optionsResolver.ResolveAsync();
+        var token = await _authService.GetAccessTokenAsync(options.AppKey, options.MasterSecret, ct);
+        if (string.IsNullOrEmpty(clientId))
+            return new AppNotificationResponse(false, "registration_id is required");
+
+        var payload = new Dictionary<string, object?>
+    {
+        { "auth_token", token },
+        { "registration_id", clientId },
+        { "tags", name }
+    };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, OppoConstants.UnsubscribeTagsUrl)
+        {
+            Content = JsonContent.Create(payload)
+        };
+
+        var response = await _httpClient.SendAsync(request, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+            return new AppNotificationResponse(false, $"Unsubscribe tag failed: {json}");
+
+        using var doc = JsonDocument.Parse(json);
+        var code = doc.RootElement.GetProperty("code").GetInt32();
+        if (code == 0)
+            return new AppNotificationResponse(true, "Unsubscribe tag succeeded");
+        else
+            return new AppNotificationResponse(false, $"Unsubscribe tag failed: {doc.RootElement.GetProperty("message").GetString()}");
+    }
 
     private async Task<AppNotificationResponse> HandleResponse(HttpResponseMessage response, CancellationToken ct)
     {

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Vivo/VivoConstants.cs
@@ -11,4 +11,6 @@ public static class VivoConstants
     public const string PushToListUrl = "https://api-push.vivo.com.cn/message/pushToList";
     public const string TagPushUrl = "https://api-push.vivo.com.cn/message/tagPush";
     public const string RecycleUrl = "https://api-push.vivo.com.cn/message/recycle";
+    public const string AddMembersUrl = "https://api-push.vivo.com.cn/tag/addMembers";
+    public const string RemoveMembersUrl = "https://api-push.vivo.com.cn/tag/removeMembers";
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiConstants.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/Xiaomi/XiaomiConstants.cs
@@ -8,4 +8,6 @@ public class XiaomiConstants
     public const string SendToRegIdUrl = "https://api.xmpush.xiaomi.com/v2/message/regid";
     public const string SendToAllUrl = "https://api.xmpush.xiaomi.com/v2/message/all";
     public const string RevokeUrl = "https://api.xmpush.xiaomi.com/v2/message/revoke";
+    public const string TopicSubscribeUrl = "https://api.xmpush.xiaomi.com/v2/topic/subscribe";
+    public const string TopicUnsubscribeUrl = "https://api.xmpush.xiaomi.com/v2/topic/unsubscribe";
 }

--- a/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/iOS/ApnsPushSender.cs
+++ b/src/Infrastructure/Masa.Mc.Infrastructure.AppNotification/iOS/ApnsPushSender.cs
@@ -11,6 +11,8 @@ public class ApnsPushSender : IAppNotificationSender
     private readonly IApnsService _apnsService;
     private readonly IOptionsResolver<IiOSPushOptions> _optionsResolver;
 
+    public bool SupportsBroadcast => false;
+
     public ApnsPushSender(IApnsService apnsService, IOptionsResolver<IiOSPushOptions> optionsResolver)
     {
         _apnsService = apnsService;
@@ -90,6 +92,17 @@ public class ApnsPushSender : IAppNotificationSender
     {
         return Task.FromResult(new AppNotificationResponse(false, "APNs does not support message withdrawal"));
     }
+
+    public Task<AppNotificationResponse> SubscribeAsync(string name, string clientId, CancellationToken ct = default)
+    {
+        return Task.FromResult(new AppNotificationResponse(false, "APNs does not support tag subscribe"));
+    }
+
+    public Task<AppNotificationResponse> UnsubscribeAsync(string name, string clientId, CancellationToken ct = default)
+    {
+        return Task.FromResult(new AppNotificationResponse(false, "APNs does not support tag unsubscribe"));
+    }
+
 
     private ApplePush CreatePush(string title, string text, string clientId, ConcurrentDictionary<string, object> transmissionContent)
     {

--- a/src/Services/Masa.Mc.Service/Application/Apps/AppNotificationSubscribeCommandHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/Apps/AppNotificationSubscribeCommandHandler.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Service.Admin.Application.Apps;
+
+public class AppNotificationSubscribeCommandHandler
+{
+    private readonly IAppVendorConfigRepository _appVendorConfigRepository;
+    private readonly ILogger<AppNotificationSubscribeCommandHandler> _logger;
+    private readonly AppNotificationSenderFactory _appNotificationSenderFactory;
+
+    public AppNotificationSubscribeCommandHandler(IAppVendorConfigRepository appVendorConfigRepository, ILogger<AppNotificationSubscribeCommandHandler> logger, AppNotificationSenderFactory appNotificationSenderFactory)
+    {
+        _appVendorConfigRepository = appVendorConfigRepository;
+        _logger = logger;
+        _appNotificationSenderFactory = appNotificationSenderFactory;
+    }
+
+    [EventHandler]
+    public async Task AppNotificationSubscribeAsync(AppNotificationSubscribeCommand command, CancellationToken cancellationToken = default)
+    {
+        var vendorConfig = await _appVendorConfigRepository.FindAsync(x => x.ChannelId == command.ChannelId && x.Vendor == (AppVendor)command.Platform);
+
+        if (vendorConfig == null)
+        {
+            _logger.LogWarning("No vendor config found for platform: {Platform}", command.Platform);
+            return;
+        }
+
+        var appSenderProvider = (Providers)command.Platform;
+        var options = _appNotificationSenderFactory.GetOptions(appSenderProvider, vendorConfig.Options);
+        var asyncLocal = _appNotificationSenderFactory.GetProviderAsyncLocal(appSenderProvider);
+
+        using (asyncLocal.Change(options))
+        {
+            var sender = _appNotificationSenderFactory.GetAppNotificationSender(appSenderProvider);
+            await sender.SubscribeAsync(AppNotificationConstants.BroadcastTag, command.DeviceToken, cancellationToken);
+        }
+    }
+
+    [EventHandler]
+    public async Task AppNotificationUnsubscribeAsync(AppNotificationUnsubscribeCommand command, CancellationToken cancellationToken = default)
+    {
+        var vendorConfig = await _appVendorConfigRepository.FindAsync(x => x.ChannelId == command.ChannelId && x.Vendor == (AppVendor)command.Platform);
+
+        if (vendorConfig == null)
+        {
+            _logger.LogWarning("No vendor config found for platform: {Platform}", command.Platform);
+            return;
+        }
+
+        var appSenderProvider = (Providers)command.Platform;
+        var options = _appNotificationSenderFactory.GetOptions(appSenderProvider, vendorConfig.Options);
+        var asyncLocal = _appNotificationSenderFactory.GetProviderAsyncLocal(appSenderProvider);
+
+        using (asyncLocal.Change(options))
+        {
+            var sender = _appNotificationSenderFactory.GetAppNotificationSender(appSenderProvider);
+            await sender.UnsubscribeAsync(AppNotificationConstants.BroadcastTag, command.DeviceToken, cancellationToken);
+        }
+    }
+}

--- a/src/Services/Masa.Mc.Service/Application/Apps/Commands/AppNotificationSubscribeCommand.cs
+++ b/src/Services/Masa.Mc.Service/Application/Apps/Commands/AppNotificationSubscribeCommand.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Service.Admin.Application.Apps.Commands;
+
+public record AppNotificationSubscribeCommand(Guid ChannelId, AppPlatform Platform, string DeviceToken) : Command;

--- a/src/Services/Masa.Mc.Service/Application/Apps/Commands/AppNotificationUnsubscribeCommand.cs
+++ b/src/Services/Masa.Mc.Service/Application/Apps/Commands/AppNotificationUnsubscribeCommand.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Service.Admin.Application.Apps.Commands;
+
+public record AppNotificationUnsubscribeCommand(Guid ChannelId, AppPlatform Platform, string DeviceToken) : Command;

--- a/src/Services/Masa.Mc.Service/Services/MessageTaskService.cs
+++ b/src/Services/Masa.Mc.Service/Services/MessageTaskService.cs
@@ -226,6 +226,15 @@ public class MessageTaskService : ServiceBase
 
             var command = new BindAppDeviceTokenCommand(channel.Id, inputDto.ClientId, inputDto.Platform.Value);
             await _eventBus.PublishAsync(command);
+
+            if (string.IsNullOrEmpty(inputDto.ClientId))
+            {
+                await _eventBus.PublishAsync(new AppNotificationUnsubscribeCommand(channel.Id, inputDto.Platform.Value, inputDto.ClientId));
+            }
+            else
+            {
+                await _eventBus.PublishAsync(new AppNotificationSubscribeCommand(channel.Id, inputDto.Platform.Value, inputDto.ClientId));
+            }
         }
 
         var systemId = $"{MasaStackProject.MC.Name}:{inputDto.ChannelCode}";


### PR DESCRIPTION
扩展推送发送器接口，新增 `SupportsBroadcast` 属性及 `SubscribeAsync` 和 `UnsubscribeAsync` 方法，统一接口实现。优化批量发送逻辑，增强事务支持与错误处理，确保数据一致性。新增 `AppNotificationSubscribeCommand` 和 `AppNotificationUnsubscribeCommand` 命令及其处理器，基于 `ClientId` 动态实现通知订阅与取消订阅功能。优化网站消息生成逻辑，扩展推送场景支持。
