### PR TITLE
refactor: Introduce user context and extend domain model support

### DIFF
--- a/src/Domain/Masa.Mc.Domain/Users/McUser.cs
+++ b/src/Domain/Masa.Mc.Domain/Users/McUser.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Mc.Domain.Users;
+
+public class McUser : MasaUser
+{
+    public string ClientId { get; set; }
+}

--- a/src/Domain/Masa.Mc.Domain/_Imports.cs
+++ b/src/Domain/Masa.Mc.Domain/_Imports.cs
@@ -1,14 +1,4 @@
-﻿// Copyright (c) MASA Stack All rights reserved.
-// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
-
-// System Namespaces
-global using System.Collections.Concurrent;
-global using System.Collections.ObjectModel;
-global using System.Linq.Expressions;
-global using System.Reflection;
-
-// MASA Building Blocks
-global using Masa.BuildingBlocks.Data;
+﻿global using Masa.BuildingBlocks.Data;
 global using Masa.BuildingBlocks.Data.Contracts;
 global using Masa.BuildingBlocks.Ddd.Domain.Entities;
 global using Masa.BuildingBlocks.Ddd.Domain.Entities.Auditing;
@@ -17,41 +7,31 @@ global using Masa.BuildingBlocks.Ddd.Domain.Events;
 global using Masa.BuildingBlocks.Ddd.Domain.Repositories;
 global using Masa.BuildingBlocks.Ddd.Domain.Values;
 global using Masa.BuildingBlocks.Dispatcher.Events;
+global using Masa.BuildingBlocks.StackSdks.Auth.Contracts;
 global using Masa.BuildingBlocks.StackSdks.Auth.Contracts.Model;
-
-// MASA MC Domain Aggregates
+global using Masa.Mc.Data;
 global using Masa.Mc.Domain.Apps.Aggregates;
 global using Masa.Mc.Domain.Channels.Aggregates;
+global using Masa.Mc.Domain.Channels.Events;
 global using Masa.Mc.Domain.MessageInfos.Aggregates;
 global using Masa.Mc.Domain.MessageRecords.Aggregates;
-global using Masa.Mc.Domain.MessageTasks.Aggregates;
-global using Masa.Mc.Domain.MessageTemplates.Aggregates;
-global using Masa.Mc.Domain.ReceiverGroups.Aggregates;
-global using Masa.Mc.Domain.WebsiteMessages.Aggregates;
-
-// MASA MC Domain Events
-global using Masa.Mc.Domain.Channels.Events;
 global using Masa.Mc.Domain.MessageRecords.Events;
+global using Masa.Mc.Domain.MessageTasks.Aggregates;
 global using Masa.Mc.Domain.MessageTasks.Events;
+global using Masa.Mc.Domain.MessageTemplates.Aggregates;
 global using Masa.Mc.Domain.MessageTemplates.Events;
-global using Masa.Mc.Domain.WebsiteMessages.Events;
-
-// MASA MC Infrastructure Helper
-global using Masa.Mc.Infrastructure.Common.Helper;
-
-// MASA MC Data
-global using Masa.Mc.Data;
-
+global using Masa.Mc.Domain.ReceiverGroups.Aggregates;
 global using Masa.Mc.Domain.Shared.Apps;
-global using Masa.Mc.Domain.Shared.Channels;
-global using Masa.Mc.Domain.Shared.MessageRecords;
+global using Masa.Mc.Domain.Shared.Consts;
 global using Masa.Mc.Domain.Shared.MessageTasks;
 global using Masa.Mc.Domain.Shared.MessageTemplates;
 global using Masa.Mc.Domain.Shared.ReceiverGroups;
-global using Masa.Mc.Domain.Shared.Subjects;
-global using Masa.Mc.Domain.Shared.WebsiteMessages;
-
-global using Masa.Mc.Domain.Shared.Consts;
+global using Masa.Mc.Infrastructure.Common.Helper;
 global using Masa.Mc.Infrastructure.Common.Utils;
-
+global using Masa.Mc.Domain.WebsiteMessages.Aggregates;
+global using Masa.Mc.Domain.WebsiteMessages.Events;
 global using Microsoft.AspNetCore.WebUtilities;
+global using System.Collections.Concurrent;
+global using System.Collections.ObjectModel;
+global using System.Linq.Expressions;
+global using System.Reflection;

--- a/src/Services/Masa.Mc.Service/Application/MessageTasks/CreateOrdinaryMessageTaskCommandHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/MessageTasks/CreateOrdinaryMessageTaskCommandHandler.cs
@@ -7,11 +7,13 @@ public class CreateOrdinaryMessageTaskCommandHandler
 {
     private readonly MessageTaskDomainService _domainService;
     private readonly IMessageInfoRepository _messageInfoRepository;
+    private readonly IUserContext _userContext;
 
-    public CreateOrdinaryMessageTaskCommandHandler(MessageTaskDomainService domainService, IMessageInfoRepository messageInfoRepositor)
+    public CreateOrdinaryMessageTaskCommandHandler(MessageTaskDomainService domainService, IMessageInfoRepository messageInfoRepositor, IUserContext userContext)
     {
         _domainService = domainService;
         _messageInfoRepository = messageInfoRepositor;
+        _userContext = userContext;
     }
 
     [EventHandler(1)]
@@ -28,6 +30,13 @@ public class CreateOrdinaryMessageTaskCommandHandler
     public async Task CreateOrdinaryMessageTaskAsync(CreateOrdinaryMessageTaskCommand createCommand)
     {
         var entity = createCommand.MessageTask.Adapt<MessageTask>();
-        await _domainService.CreateAsync(entity, createCommand.MessageTask.SystemId);
+        var systemId = createCommand.MessageTask.SystemId;
+
+        if (string.IsNullOrEmpty(systemId))
+        {
+            systemId = _userContext.GetUser<McUser>()?.ClientId ?? string.Empty;
+        }
+
+        await _domainService.CreateAsync(entity, systemId);
     }
 }

--- a/src/Services/Masa.Mc.Service/Application/MessageTasks/CreateTemplateMessageTaskCommandHandler.cs
+++ b/src/Services/Masa.Mc.Service/Application/MessageTasks/CreateTemplateMessageTaskCommandHandler.cs
@@ -7,11 +7,13 @@ public class CreateTemplateMessageTaskCommandHandler
 {
     private readonly MessageTaskDomainService _domainService;
     private readonly IMessageTemplateRepository _messageTemplateRepository;
+    private readonly IUserContext _userContext;
 
-    public CreateTemplateMessageTaskCommandHandler(MessageTaskDomainService domainService, IMessageTemplateRepository messageTemplateRepository)
+    public CreateTemplateMessageTaskCommandHandler(MessageTaskDomainService domainService, IMessageTemplateRepository messageTemplateRepository, IUserContext userContext)
     {
         _domainService = domainService;
         _messageTemplateRepository = messageTemplateRepository;
+        _userContext = userContext;
     }
 
     [EventHandler(1)]
@@ -40,6 +42,13 @@ public class CreateTemplateMessageTaskCommandHandler
     public async Task CreateTemplateMessageTaskAsync(CreateTemplateMessageTaskCommand createCommand)
     {
         var entity = createCommand.MessageTask.Adapt<MessageTask>();
-        await _domainService.CreateAsync(entity, createCommand.MessageTask.SystemId);
+        var systemId = createCommand.MessageTask.SystemId;
+
+        if (string.IsNullOrEmpty(systemId))
+        {
+            systemId = _userContext.GetUser<McUser>()?.ClientId ?? string.Empty;
+        }
+
+        await _domainService.CreateAsync(entity, systemId);
     }
 }

--- a/src/Services/Masa.Mc.Service/Program.cs
+++ b/src/Services/Masa.Mc.Service/Program.cs
@@ -40,9 +40,10 @@ builder.Services.AddMasaIdentity(options =>
     options.Environment = "environment";
     options.UserName = "name";
     options.UserId = "sub";
-    options.Mapping(nameof(MasaUser.CurrentTeamId), IdentityClaimConsts.CURRENT_TEAM);
-    options.Mapping(nameof(MasaUser.StaffId), IdentityClaimConsts.STAFF);
-    options.Mapping(nameof(MasaUser.Account), IdentityClaimConsts.ACCOUNT);
+    options.Mapping(nameof(McUser.CurrentTeamId), IdentityClaimConsts.CURRENT_TEAM);
+    options.Mapping(nameof(McUser.StaffId), IdentityClaimConsts.STAFF);
+    options.Mapping(nameof(McUser.Account), IdentityClaimConsts.ACCOUNT);
+    options.Mapping(nameof(McUser.ClientId), "client_id");
 });
 builder.Services.AddAuthorization();
 builder.Services.AddAuthentication(options =>

--- a/src/Services/Masa.Mc.Service/_Imports.cs
+++ b/src/Services/Masa.Mc.Service/_Imports.cs
@@ -103,6 +103,7 @@ global using Masa.Mc.Domain.Shared.WebsiteMessages;
 global using Masa.Mc.Domain.WebsiteMessages.Aggregates;
 global using Masa.Mc.Domain.WebsiteMessages.Events;
 global using Masa.Mc.Domain.WebsiteMessages.Repositories;
+global using Masa.Mc.Domain.Users;
 global using Masa.Mc.EntityFrameworkCore;
 global using Masa.Mc.Infrastructure.AppNotification;
 global using Masa.Mc.Infrastructure.AppNotification.Extensions;


### PR DESCRIPTION
-Add '_userContext' field and 'systemId' default value logic in 'CreateOrdinariMessageTaskCommandHandler' and 'CreateTemplateMessageTaskCommandHandler'.

-Add 'McUser' class, extend 'MasaUser', and add 'ClientId' attribute.

-Optimize the 'using' directive of the '_Imports. cs' file, delete useless namespaces, and introduce new namespaces.

-Update the 'Program. cs' configuration and support the mapping of' McUser. ClientId '.